### PR TITLE
Fix/traefik routes maintenance page and testing

### DIFF
--- a/services/maintenance-page/docker-compose.yml.j2
+++ b/services/maintenance-page/docker-compose.yml.j2
@@ -26,7 +26,7 @@ services:
         - traefik.docker.network=${PUBLIC_NETWORK}
         - traefik.http.routers.{{"maintenance_page_web_" + j2item.replace('@','').replace(' ','').replace('.','').replace('-','').replace('\'','') + "_html"}}.priority={{MAINTENANCE_PAGES_TRAEFIK_PRIORITY}}
         - traefik.http.routers.{{"maintenance_page_web_" + j2item.replace('@','').replace(' ','').replace('.','').replace('-','').replace('\'','') + "_html"}}.rule={{  "Host(`" + j2item + "`)" }}
-        - traefik.http.routers.{{"maintenance_page_web_" + j2item.replace('@','').replace(' ','').replace('.','').replace('-','').replace('\'','') + "_html"}}.rule=(Host(`{{j2item}}`) && PathPrefix(`/`)) || (HostRegexp(`services.{{j2item}}`,`{subhost:[a-zA-Z0-9-]+}.services.{{j2item}}`) && PathPrefix(`/`)) || (HostRegexp(`services.testing.{{j2item}}`,`{subhost:[a-zA-Z0-9-]+}.services.testing.{{j2item}}`) && PathPrefix(`/`))
+        - traefik.http.routers.{{"maintenance_page_web_" + j2item.replace('@','').replace(' ','').replace('.','').replace('-','').replace('\'','') + "_html"}}.rule=(Host(`{{j2item}}`) && PathPrefix(`/`)) || (HostRegexp(`services.{{j2item}}`,`{subhost:[a-zA-Z0-9-]+}.services.{{j2item}}`) && PathPrefix(`/`))
         - traefik.http.routers.{{"maintenance_page_web_" + j2item.replace('@','').replace(' ','').replace('.','').replace('-','').replace('\'','') + "_html"}}.tls=true
         - traefik.http.routers.{{"maintenance_page_web_" + j2item.replace('@','').replace(' ','').replace('.','').replace('-','').replace('\'','') + "_html"}}.tls.certresolver=myresolver
         - traefik.http.services.{{"maintenance_page_web_" + j2item.replace('@','').replace(' ','').replace('.','').replace('-','').replace('\'','') + "_html"}}.loadbalancer.server.port=80

--- a/services/traefik/docker-compose.letsencrypt.dns.yml.j2
+++ b/services/traefik/docker-compose.letsencrypt.dns.yml.j2
@@ -12,5 +12,6 @@ services:
         - traefik.http.routers.{{j2item.replace('@','').replace(' ','').replace('.','').replace('-','').replace('\'','')}}.tls.domains[0].sans=*.services.{{j2item.replace(' ','').replace('\'','')}}
         - traefik.http.routers.{{j2item.replace('@','').replace(' ','').replace('.','').replace('-','').replace('\'','')}}testing.tls.domains[0].main=service.testing.{{j2item.replace(' ','').replace('\'','')}}
         - traefik.http.routers.{{j2item.replace('@','').replace(' ','').replace('.','').replace('-','').replace('\'','')}}testing.tls.domains[0].sans=*.services.testing.{{j2item.replace(' ','').replace('\'','')}}
+        - traefik.http.routers.{{j2item.replace('@','').replace(' ','').replace('.','').replace('-','').replace('\'','')}}testing.tls.certresolver=myresolver
         - traefik.http.routers.{{j2item.replace('@','').replace(' ','').replace('.','').replace('-','').replace('\'','')}}.tls.certresolver=myresolver
 {% endfor %}


### PR DESCRIPTION
- Adds traefik rules to obain certificates for `UUID.services.testing` routes (i.e. dynamic service container via testing routes)
- Fixes bug: Testing dynamic services are no longer captures by the maintenance page

Fixes git.speag.com/oSparc/osparc-ops-environments/-/issues/429