### PR TITLE
V1.46.0

### DIFF
--- a/services/maintenance-page/docker-compose.yml.j2
+++ b/services/maintenance-page/docker-compose.yml.j2
@@ -26,7 +26,7 @@ services:
         - traefik.docker.network=${PUBLIC_NETWORK}
         - traefik.http.routers.{{"maintenance_page_web_" + j2item.replace('@','').replace(' ','').replace('.','').replace('-','').replace('\'','') + "_html"}}.priority={{MAINTENANCE_PAGES_TRAEFIK_PRIORITY}}
         - traefik.http.routers.{{"maintenance_page_web_" + j2item.replace('@','').replace(' ','').replace('.','').replace('-','').replace('\'','') + "_html"}}.rule={{  "Host(`" + j2item + "`)" }}
-        - traefik.http.routers.{{"maintenance_page_web_" + j2item.replace('@','').replace(' ','').replace('.','').replace('-','').replace('\'','') + "_html"}}.rule=(Host(`{{j2item}}`) && PathPrefix(`/`)) || (HostRegexp(`services.{{j2item}}`,`{subhost:[a-zA-Z0-9-]+}.services.{{j2item}}`) && PathPrefix(`/`)) || (HostRegexp(`services.testing.{{j2item}}`,`{subhost:[a-zA-Z0-9-]+}.services.testing.{{j2item}}`) && PathPrefix(`/`))
+        - traefik.http.routers.{{"maintenance_page_web_" + j2item.replace('@','').replace(' ','').replace('.','').replace('-','').replace('\'','') + "_html"}}.rule=(Host(`{{j2item}}`) && PathPrefix(`/`)) || (HostRegexp(`services.{{j2item}}`,`{subhost:[a-zA-Z0-9-]+}.services.{{j2item}}`) && PathPrefix(`/`))
         - traefik.http.routers.{{"maintenance_page_web_" + j2item.replace('@','').replace(' ','').replace('.','').replace('-','').replace('\'','') + "_html"}}.tls=true
         - traefik.http.routers.{{"maintenance_page_web_" + j2item.replace('@','').replace(' ','').replace('.','').replace('-','').replace('\'','') + "_html"}}.tls.certresolver=myresolver
         - traefik.http.services.{{"maintenance_page_web_" + j2item.replace('@','').replace(' ','').replace('.','').replace('-','').replace('\'','') + "_html"}}.loadbalancer.server.port=80

--- a/services/simcore/docker-compose.yml
+++ b/services/simcore/docker-compose.yml
@@ -149,7 +149,9 @@ services:
         delay: 5s
         max_attempts: 3
         window: 120s
-
+  invitations:
+    environment:
+      - INVITATIONS_LOGLEVEL=${INVITATIONS_LOGLEVEL}
   webserver:
     networks:
       - public


### PR DESCRIPTION
- Add invitation_loglevel var to the simcore invitations service. (#435 ops)
- Update traefik router to not redirect testing routes in the maintenance page.