### PR TITLE
Add functioning graylog alert for director-v2 issue (PoolTimeout) [🚧]

### DIFF
--- a/services/graylog/scripts/alerts.template.yaml
+++ b/services/graylog/scripts/alerts.template.yaml
@@ -158,3 +158,36 @@
     grace_period_ms: 0
     backlog_size:
   alert: true
+- title: "${MACHINE_FQDN}: CRITICAL director-v2 error. Plattform operations impaired. Director-v2 restart required."
+  description: "${MACHINE_FQDN}: CRITICAL director-v2 error. Plattform operations impaired. Director-v2 restart required."
+  priority: 3
+  config:
+    query: >
+      '"WARNING:simcore_service_director_v2.modules.dynamic_sidecar.api_client._base:Pool status @ 'POOL TIMEOUT'" AND NOT container_name:/.*graylog_graylog.*/'
+    query_parameters: []
+    search_within_ms: 600000
+    execute_every_ms: 600000
+    group_by: []
+    series: []
+    conditions: {}
+    type: aggregation-v1
+  field_spec:
+    source:
+      data_type: string
+      providers:
+      - type: template-v1
+        template: "${source.source}"
+        require_values: false
+    container_name:
+      data_type: string
+      providers:
+      - type: template-v1
+        template: "${source.container_name}"
+        require_values: false
+  key_spec:
+    - source
+    - container_name
+  notification_settings:
+    grace_period_ms: 0
+    backlog_size:
+  alert: true


### PR DESCRIPTION
This refers to: `https://git.speag.com/oSparc/osparc-ops-environments/-/issues/439`

This adds a mattermost alert for the issue mentioned in https://github.com/ITISFoundation/osparc-simcore/pull/3878

========================

🚧🚧🚧
This needs to be propagated to prod asap
🚧🚧🚧