### PR TITLE
Add missing prometheus rules 🚧🚧🚧

### DIFF
--- a/services/monitoring/prometheus/README.md
+++ b/services/monitoring/prometheus/README.md
@@ -1,14 +1,12 @@
 # [prometheus]
 
-![GitHub last commit](https://img.shields.io/github/last-commit/prometheus/prometheus?label=github%20last%20commit)
-[![Docker Pulls](https://img.shields.io/docker/pulls/prom/prometheus.svg)](https://hub.docker.com/r/prom/prometheus/tags)
-
-
-![](https://cdn.rawgit.com/prometheus/prometheus/e761f0d/documentation/images/architecture.svg)
-
 
 [prometheus] is a monitoring system and time-series database
 
 
 <!-- References below -->
 [prometheus]:https://prometheus.io/
+
+#### Tricks and Tips:
+Fill in past data for new rules (make sure to backup data before)
+- https://jessicagreben.medium.com/prometheus-fill-in-data-for-new-recording-rules-30a14ccb8467

--- a/services/monitoring/prometheus/prometheus.rules.yml
+++ b/services/monitoring/prometheus/prometheus.rules.yml
@@ -18,25 +18,32 @@ groups:
     rules:
       - record: simcore_simcore_service_director_services_started_total:sum_by_service_key_service_tag
         expr: sum by (service_key, service_tag, deployment)(simcore_simcore_service_director_services_started_total)
-
   - name: node_cpu_seconds_total-nonidle-sum_over_nodes
     rules:
       - record: node_cpu_seconds_total:nonidle_sum_over_nodes
         expr: sum(node_cpu_seconds_total{mode!="idle"})
-
   - name: node_cpu_seconds_total-nonidle-increase-over-nodes-12weeks
     interval: 1h
     rules:
       - record: node_cpu_seconds_total:nonidle_increase_over_nodes_12weeks
         expr: sum(increase(node_cpu_seconds_total{mode!="idle"}[12w]))
-
   - name: cpu_usage_per_simcore_service
     interval: 120s
     rules:
       - record: osparc_metrics:cpu_usage_per_simcore_service
-        expr: sum by (service_name, instance) (label_replace(irate(container_cpu_usage_seconds_total{container_label_com_docker_swarm_service_name=~".*simcore.*"}[1m]), "service_name", "$1", "container_label_com_docker_swarm_service_name", ".*_(.*)")) * 100
+        expr: sum by (service_name, instance, node_name) (label_replace(irate(container_cpu_usage_seconds_total{container_label_com_docker_swarm_service_name=~".*simcore.*"}[1m]), "service_name", "$1", "container_label_com_docker_swarm_service_name", ".*_(.*)")) * 100
   - name: cpu_usage_per_node
     interval: 60s
     rules:
-      - record: osparc_metrics:cpu_usage_per_node
-        expr: 100 - (avg(irate(node_cpu_seconds_total{job="node-exporter",mode="idle"}[50s]) * on(instance) group_left(node_name) node_meta{}) by (instance) * 100)
+      - record: osparc_metrics:cpu_usage_per_node_percentage
+        expr: 100 - (avg(irate(node_cpu_seconds_total{job="node-exporter",mode="idle"}[50s])) by (instance,node_name) * 100)
+  - name: cpu_seconds_per_node
+    interval: 60s
+    rules:
+      - record: osparc_metrics:cpu_seconds_per_node
+        expr: sum by (instance) (node_cpu_seconds_total{mode!="idle", job="node-exporter"})
+  - name: node_cpu_seconds_total-nonidle-increase-over-nodes-12weeks-v2
+    interval: 180s
+    rules:
+      - record: node_cpu_seconds_total_v2:nonidle_increase_over_nodes_12weeks_v2
+        expr: sum(increase(osparc_metrics:cpu_seconds_per_node[12w]))


### PR DESCRIPTION
Two prometheus rules got missing during the large osparc-ops-environements refactoring.

When this PR propagates, prometheus has to be restarted.
Since we had issues in the past, making a backup of the prometheus docker volume is wise
In order to make past data available in these new rules, please follow https://jessicagreben.medium.com/prometheus-fill-in-data-for-new-recording-rules-30a14ccb8467