### PR TITLE
change agent deploy policy

### DIFF
--- a/services/simcore/docker-compose.yml
+++ b/services/simcore/docker-compose.yml
@@ -66,7 +66,7 @@ services:
           - node.labels.dynamicsidecar==true
       update_config:
         parallelism: 2
-        order: start-first
+        order: stop-first
         failure_action: rollback
         delay: 10s
       rollback_config:


### PR DESCRIPTION
Since the agent registers RPC calls on startup and these cannot overlap, it is required that the service is fully stopped before a new instance is started.

@mrnicegyu11 I hope this is the correct place to change it

- required by https://github.com/ITISFoundation/osparc-simcore/pull/3941