### PR TITLE
♻️ Alert/add hanging sidecar alert + improve grace periods

### DIFF
--- a/services/graylog/scripts/alerts.template.yaml
+++ b/services/graylog/scripts/alerts.template.yaml
@@ -271,12 +271,12 @@
     grace_period_ms: 0
     backlog_size:
   alert: true
-- title: "${MACHINE_FQDN}: Potential hanging dy-sidecar service detected. Please investigate."
-  description: "${MACHINE_FQDN}: Potential hanging dy-sidecar service detected. Please investigate."
+- title: "${MACHINE_FQDN}: Potential hanging dy-sidecar service detected."
+  description: "${MACHINE_FQDN}: Potential hanging dy-sidecar service detected. Human intervention required. Please investigate."
   priority: 3
   config:
     query: >
-      "unexpectedly failed [OEC" AND container_name:/.*director-v2.*/
+      "not contact dynamic-sidecar to save service state or output ports" AND container_name:/.*director-v2.*/
     query_parameters: []
     search_within_ms: 3600000
     execute_every_ms: 3600000
@@ -305,7 +305,6 @@
   key_spec:
     - source
     - container_name
-    - full_message
   notification_settings:
     grace_period_ms: 0
     backlog_size:

--- a/services/monitoring/grafana/provisioning/allDeployments/alerts/osparc_alerts.json
+++ b/services/monitoring/grafana/provisioning/allDeployments/alerts/osparc_alerts.json
@@ -4,7 +4,7 @@
   "rules": [
     {
       "expr": "",
-      "for": "3m",
+      "for": "10m",
       "grafana_alert": {
         "condition": "B",
         "data": [
@@ -83,7 +83,7 @@
     },
     {
       "expr": "",
-      "for": "5m",
+      "for": "2h",
       "grafana_alert": {
         "condition": "C",
         "data": [
@@ -91,7 +91,7 @@
             "datasourceUid": "RmZEr52nz",
             "model": {
               "editorMode": "code",
-              "expr": "sum(avg_over_time(swarm_manager_tasks_total{state=\"pending\"}[30m]))",
+              "expr": "sum(swarm_manager_tasks_total{state=\"pending\"})",
               "hide": false,
               "intervalMs": 1000,
               "legendFormat": "__auto",
@@ -102,7 +102,7 @@
             "queryType": "",
             "refId": "A",
             "relativeTimeRange": {
-              "from": 900,
+              "from": 1800,
               "to": 0
             }
           },
@@ -138,7 +138,7 @@
               "hide": false,
               "intervalMs": 1000,
               "maxDataPoints": 43200,
-              "reducer": "mean",
+              "reducer": "min",
               "refId": "B",
               "settings": {
                 "mode": "replaceNN",
@@ -149,7 +149,7 @@
             "queryType": "",
             "refId": "B",
             "relativeTimeRange": {
-              "from": 900,
+              "from": 1800,
               "to": 0
             }
           },
@@ -193,19 +193,15 @@
             "queryType": "",
             "refId": "C",
             "relativeTimeRange": {
-              "from": 900,
+              "from": 1800,
               "to": 0
             }
           }
         ],
         "exec_err_state": "Error",
-        "id": 12,
         "intervalSeconds": 60,
         "is_paused": false,
-        "namespace_id": 222,
-        "namespace_uid": "_Zc_rbJ4k",
         "no_data_state": "NoData",
-        "orgId": 1,
         "rule_group": "osparc_alerts",
         "title": "pending_services_alert",
         "uid": "rLDQaif4z",
@@ -218,7 +214,7 @@
         "description": "When logspout is swapping, this can cause the nodes to become unresponsive due to heavy IO loads"
       },
       "expr": "",
-      "for": "5m",
+      "for": "2h",
       "grafana_alert": {
         "condition": "C",
         "data": [
@@ -334,18 +330,13 @@
           }
         ],
         "exec_err_state": "Error",
-        "id": 26,
         "intervalSeconds": 60,
         "is_paused": false,
-        "namespace_id": 326,
-        "namespace_uid": "YrUJEmf4k",
         "no_data_state": "NoData",
-        "orgId": 1,
         "rule_group": "osparc_alerts",
         "title": "logspout_swapping",
-        "uid": "hX31Pmf4kz",
-        "updated": "2023-03-22T09:18:25Z",
-        "version": 3
+        "updated": "2023-03-29T16:08:32Z",
+        "version": 5
       }
     }
   ]


### PR DESCRIPTION
This PR
- Adds a new alert for hanging sidecars that require human intervention
- Changes alerting grace periods on grafana alerts to avoid spam
- Changes how alert for pending docker services work: it now asserts that at least at one instance (once) in the last 2h there were no pending docker services. This removes autoscaling related false positives on aws-prod