### PR TITLE
🗑️Remove mailserver automatic starting from aws

### DIFF
--- a/scripts/deployments/deploy.sh
+++ b/scripts/deployments/deploy.sh
@@ -247,7 +247,7 @@ if [ "$start_opsstack" -eq 0 ]; then
     call_make "." up-"$stack_target"
     popd
 
-    if [ "$stack_target" = "aws" ] || [ "$stack_target" = "local" ]; then
+    if [ "$stack_target" = "local" ]; then
         # -------------------------------- Mail -------------------------------
         log_info "starting mail server..."
         pushd "${repo_basedir}"/services/mail

--- a/services/mail/README.md
+++ b/services/mail/README.md
@@ -1,0 +1,3 @@
+# THIS IS DEPRECATED
+
+On all deployments we now use a AWS SES based mail-delivery system. This docker-mailserver is deprecated and may only be useful for local testing.


### PR DESCRIPTION
We now use a AWS SES based mail-delivery, the docker-mailserver is only used for the local deployment now.