### PR TITLE
✨ Add custom itisfoundation docker events exporter

### DIFF
--- a/services/monitoring/docker-compose.yml.j2
+++ b/services/monitoring/docker-compose.yml.j2
@@ -176,7 +176,7 @@ services:
           memory: 256M
 
   docker-events-exporter:
-    image: ghcr.io/codestation/docker-events-exporter:latest@sha256:cdf365de6880f68cfba0a779faf6f5f9b0c5bbe3c6ddcddc903c1dbecfd11e93
+    image: itisfoundation/docker-events-exporter:latest
     volumes:
      - /var/run/docker.sock:/var/run/docker.sock:ro
     user: root # only user root can use the docker socket

--- a/services/monitoring/grafana/provisioning/allDeployments/alerts/osparc_alerts.json
+++ b/services/monitoring/grafana/provisioning/allDeployments/alerts/osparc_alerts.json
@@ -214,7 +214,7 @@
         "summary": "Checks for container killed, non-zero exit code shutdown or oom-event. Restart the docker-events-exporter after tracing the unexpected shutdown to reset the alert."
       },
       "expr": "",
-      "for": "5m",
+      "for": "4m",
       "grafana_alert": {
         "condition": "C",
         "data": [
@@ -222,7 +222,7 @@
             "datasourceUid": "RmZEr52nz",
             "model": {
               "editorMode": "code",
-              "expr": "absent(docker_events) or on() vector(0)",
+              "expr": "increase(docker_events{action=\"oom\"}[1m]) > 0",
               "hide": false,
               "intervalMs": 1000,
               "legendFormat": "__auto",
@@ -233,7 +233,7 @@
             "queryType": "",
             "refId": "A",
             "relativeTimeRange": {
-              "from": 600,
+              "from": 300,
               "to": 0
             }
           },
@@ -269,14 +269,17 @@
               "hide": false,
               "intervalMs": 1000,
               "maxDataPoints": 43200,
-              "reducer": "last",
+              "reducer": "max",
               "refId": "B",
+              "settings": {
+                "mode": "dropNN"
+              },
               "type": "reduce"
             },
             "queryType": "",
             "refId": "B",
             "relativeTimeRange": {
-              "from": 600,
+              "from": 300,
               "to": 0
             }
           },
@@ -287,9 +290,9 @@
                 {
                   "evaluator": {
                     "params": [
-                      0.9
+                      0.0001
                     ],
-                    "type": "lt"
+                    "type": "gt"
                   },
                   "operator": {
                     "type": "and"
@@ -320,7 +323,7 @@
             "queryType": "",
             "refId": "C",
             "relativeTimeRange": {
-              "from": 600,
+              "from": 300,
               "to": 0
             }
           }
@@ -331,8 +334,8 @@
         "no_data_state": "NoData",
         "rule_group": "osparc_alerts",
         "title": "container_died_killed_oom_event",
-        "updated": "2023-04-12T12:19:35Z",
-        "version": 2
+        "updated": "2023-04-17T09:34:58Z",
+        "version": 3
       }
     },
     {

--- a/services/traefik/docker-compose.yml.j2
+++ b/services/traefik/docker-compose.yml.j2
@@ -51,10 +51,10 @@ services:
       resources:
         limits:
           memory: 2048M
-          cpus: '2.000'
+          cpus: '3.000'
         reservations:
           memory: 2048M
-          cpus: '2.000'
+          cpus: '3.000'
       placement:
         constraints:
           - node.role == manager


### PR DESCRIPTION
This goes with https://github.com/ITISFoundation/docker-events-exporter/pull/1

- ✨ Adds a customized version of the docker-events exporter via docker image `itisfoundation/docker-events-exporter:latest`
- ♻️ Increases ops-traefik CPU limitation&reservation from `2` to `3` (since excessive throttling is seen on master01)
- ✨ Adds grafana alert for docker container oom events