### PR TITLE
🚧🐛 Fix deployment agent config on clusters with multiple deployments

### DIFF
--- a/services/deployment-agent/.gitignore
+++ b/services/deployment-agent/.gitignore
@@ -1,1 +1,2 @@
 deployment_config.yml
+docker-compose.yml

--- a/services/deployment-agent/Makefile
+++ b/services/deployment-agent/Makefile
@@ -3,7 +3,16 @@ REPO_BASE_DIR := $(shell git rev-parse --show-toplevel)
 # Makefile including function used by every services
 include ${REPO_BASE_DIR}/scripts/common.Makefile
 
+# Helpers -------------------------------------------------
+.venv:
+	# creating virtual environment with tooling (jinja, etc)
+	@python3 -m venv .venv
+	@.venv/bin/pip3 install --upgrade pip wheel setuptools
+	@.venv/bin/pip3 install jinja2 j2cli[yaml]
 
+define jinja
+	@.venv/bin/j2 --format=env $(1) $(2) -o $(3)
+endef
 
 #
 include ${REPO_CONFIG_LOCATION}
@@ -57,7 +66,6 @@ down: ## Stops and remove stack from swarm
 	-@docker stack rm ${SIMCORE_STACK_NAME}
 
 
-# Helpers -------------------------------------------------
 .PHONY: ${DEPLOYMENT_AGENT_CONFIG}
 ${DEPLOYMENT_AGENT_CONFIG}: .env
 	@set -o allexport; \
@@ -66,6 +74,10 @@ ${DEPLOYMENT_AGENT_CONFIG}: .env
 	set +o allexport; \
 	envsubst < ${DEPLOYMENT_AGENT_CONFIG_DEFAULT} > $@
 
+
+.PHONY: docker-compose.yml
+docker-compose.yml: .env docker-compose.yml.j2 .venv
+	$(call jinja, docker-compose.yml.j2, .env, docker-compose.yml)
 
 .PHONY: ${TEMP_COMPOSE}
 ${TEMP_COMPOSE}: .env $(docker-compose-configs)

--- a/services/deployment-agent/docker-compose.yml.j2
+++ b/services/deployment-agent/docker-compose.yml.j2
@@ -1,14 +1,14 @@
 version: "3.8"
 services:
   auto-deployment-agent:
-    image: ${DOCKER_REGISTRY}/deployment-agent:0.11.2
+    image: {{DOCKER_REGISTRY}}/deployment-agent:0.11.2
     init: true
     ports:
       - "8888"
     configs:
-      - source: deployment_config
+      - source: {{PREFIX_STACK_NAME}}_deployment_config
         target: /home/scu/config-prod.yaml
-      - source: create_stack_script
+      - source: {{PREFIX_STACK_NAME}}_create_stack_script
         target: /home/scu/startup_script.bash
         mode: 0555
     networks:
@@ -27,7 +27,7 @@ networks:
     external: true
 
 configs:
-  deployment_config:
-    file: ./${DEPLOYMENT_AGENT_CONFIG}
-  create_stack_script:
+  {{PREFIX_STACK_NAME}}_deployment_config:
+    file: ./{{DEPLOYMENT_AGENT_CONFIG}}
+  {{PREFIX_STACK_NAME}}_create_stack_script:
     file: ./startup_script.bash


### PR DESCRIPTION
On clusters running multiple simcore stacks, such as osparc-dalco, a bug was discovered. All deployment-agents would run using the same config-files (accessed via docker configs), and the simcore stacks might get into a weird state, neither running fully staging or production configuration.

This PR addresses this by inserting the STACK_PREFIX into the name of the docker configs using j2 templates, thereby enforcing a single unique docker config per simcore stack.



🚧🚧🚧:
Once this propagates through the deployments, the docker stacks of the deployment agents need to be re-created.