### PR TITLE
Fix bad configuration for dns challenge resolver

### DIFF
--- a/services/traefik/docker-compose.public.yml
+++ b/services/traefik/docker-compose.public.yml
@@ -31,7 +31,7 @@ services:
       - "--certificatesresolvers.myresolver.acme.storage=/letsencrypt/acme.json"
       # For debug purpose, to avoid being ban by let's encrypt servers
       #- "--certificatesresolvers.myresolver.acme.caserver=https://acme-staging-v02.api.letsencrypt.org/directory"
-      - "--certificatesresolvers.myresolver.acme.dnschallenge.resolvers=${CERTIFICATE_RESOLVE_DNS_CHALLANGE_IP}"
+      - "--certificatesresolvers.myresolver.acme.dnschallenge.resolvers=${RFC2136_NAMESERVER}"
     volumes:
       - "letsencrypt_certs:/letsencrypt"
     environment:


### PR DESCRIPTION
This PR : 

- Fix a bad configuration for DNS challenges that are done by Traefik. Let's encrypt servers couldn't solve properly the challenge because the variable used to indicate which DNS server to look at while doing so was not properly set up. 