### PR TITLE
✨ Add SmokePing Grafana Dashboard and Prometheus Exporter

### DIFF
--- a/services/admin-panels/README.md
+++ b/services/admin-panels/README.md
@@ -1,22 +1,18 @@
-# adminpanels stack
-
-## quickstart / tl; dr
-1. In the admin jupyter, open a terminal
-2. Run `sudo adminPanelsGitInit.bash` to update the admin panels from github to the latest version
-3. Navigate to `~/osparc-support`
-4. Run admin panels
+# admin-panels stack
 
 
 ## Details
 
-This admin-panel service is attached to all relevant docker networks of the sicore stack to communicate with postgres, redis, and simcore microservices.
-All relevant credentials are previded as env-vars in the admin-panels.
-The admin-panels should be coded in a way to use the env-vars provided by the admin-panel service
+This admin-panel service is attached to all relevant docker networks of the simcore stack to communicate with postgres, redis, and simcore microservices.
+All relevant credentials are provided as env-vars in the admin-panels.
 
-If you make modifications to the admin-panels, they cannot be pushed to git directly. You are expected to make a formal PR to the `osparc-support` repo on github.
+If you make modifications to the admin-panels inside the admin-panels jupyter (i.e. on a live deployment), they cannot be pushed to git directly. You are expected to make a formal PR to this repo on github.
 
 ## Caveats
 
-- Currently, the admin panels are not designed to handle multiple parallel users. Weird things may happen/
-- There is no data persistancy in the admin panel jupyter. It is recommended to always execute a fresh pull from github (via `sudo adminPanelsGitInit.bash`) before using the panels
+- Currently, the admin panels are not designed to handle multiple parallel users. Weird things may happen.
+- There is no data persistancy in the admin panel jupyter. Files have to be added to the git-repo https://github.com/ITISFoundation/osparc-ops-environments via PR to be persistant
 - The admin-panels will not work for dalco-staging, as two deployments on the same swarm can currently not be handled.
+
+## How to add new admin scripts
+- Make a PR to https://github.com/ITISFoundation/osparc-ops-environments and simply drop the `.py` or `.ipynb` files in  `osparc-ops-environments/services/admin-panels/data`

--- a/services/monitoring/docker-compose.yml.j2
+++ b/services/monitoring/docker-compose.yml.j2
@@ -29,6 +29,8 @@ configs:
     file: ./grafana-image-renderer/config.json
   pgsql_query_exporter_config:
     file: ./pgsql_query_exporter_config.yaml
+  smokeping_prober_config:
+    file: ./smokeping_prober_config.yaml
 services:
   prometheus:
     image: prom/prometheus:v2.40.7
@@ -236,6 +238,30 @@ services:
       resources:
         limits:
           memory: 512M
+        reservations:
+          memory: 64M
+
+  smokeping-prober-exporter:
+    image: quay.io/superq/smokeping-prober:latest
+    networks:
+      - internal
+      - monitored
+    volumes: []
+    cap_add:
+      - SYS_ADMIN
+    entrypoint:
+      /bin/smokeping_prober --config.file=/smokeping_prober_config.yaml
+    configs:
+      - source: smokeping_prober_config
+        target: /smokeping_prober_config.yaml
+    deploy:
+      labels:
+        - prometheus-job=smokeping-prober-exporter
+        - prometheus-port=9374
+      mode: global
+      resources:
+        limits:
+          memory: 128M
         reservations:
           memory: 64M
 

--- a/services/monitoring/docker-compose.yml.j2
+++ b/services/monitoring/docker-compose.yml.j2
@@ -248,7 +248,8 @@ services:
       - monitored
     volumes: []
     cap_add:
-      - SYS_ADMIN
+      - 'NET_ADMIN'
+      - 'NET_RAW'
     entrypoint:
       /bin/smokeping_prober --config.file=/smokeping_prober_config.yaml
     configs:

--- a/services/monitoring/docker-compose.yml.j2
+++ b/services/monitoring/docker-compose.yml.j2
@@ -242,7 +242,7 @@ services:
           memory: 64M
 
   smokeping-prober-exporter:
-    image: quay.io/superq/smokeping-prober:latest
+    image: quay.io/superq/smokeping-prober:v0.6.1
     networks:
       - internal
       - monitored

--- a/services/monitoring/grafana/provisioning/allDeployments/dashboards/ops/SmokePing.json
+++ b/services/monitoring/grafana/provisioning/allDeployments/dashboards/ops/SmokePing.json
@@ -1,0 +1,384 @@
+{
+  "dashboard": {
+    "annotations": {
+      "list": [
+        {
+          "builtIn": 1,
+          "datasource": "-- Grafana --",
+          "enable": true,
+          "hide": true,
+          "iconColor": "rgba(0, 211, 255, 1)",
+          "name": "Annotations & Alerts",
+          "type": "dashboard"
+        }
+      ]
+    },
+    "description": "Smoke Ping using https://github.com/SuperQ/smokeping_prober\r\nwith \r\nlatency heatmap\r\nlatency graph\r\npacket loss gragh\r\n",
+    "editable": true,
+    "gnetId": 11335,
+    "graphTooltip": 0,
+    "iteration": 1575365807798,
+    "links": [],
+    "panels": [
+      {
+        "cards": {
+          "cardPadding": null,
+          "cardRound": null
+        },
+        "color": {
+          "cardColor": "#FF9830",
+          "colorScale": "sqrt",
+          "colorScheme": "interpolateOranges",
+          "exponent": 0.5,
+          "mode": "opacity"
+        },
+        "dataFormat": "tsbuckets",
+        "datasource": "RmZEr52nz",
+        "gridPos": {
+          "h": 10,
+          "w": 12,
+          "x": 0,
+          "y": 0
+        },
+        "heatmap": {},
+        "hideZeroBuckets": false,
+        "highlightCards": true,
+        "id": 2,
+        "legend": {
+          "show": false
+        },
+        "links": [],
+        "options": {},
+        "reverseYBuckets": false,
+        "targets": [
+          {
+            "expr": "sum(rate(smokeping_response_duration_seconds_bucket{host=\"$target\"}[1m])) by (le)",
+            "format": "heatmap",
+            "intervalFactor": 1,
+            "legendFormat": "{{le}}",
+            "refId": "A"
+          }
+        ],
+        "title": "Smoke Ping - $target",
+        "tooltip": {
+          "show": true,
+          "showHistogram": false
+        },
+        "type": "heatmap",
+        "xAxis": {
+          "show": true
+        },
+        "xBucketNumber": null,
+        "xBucketSize": null,
+        "yAxis": {
+          "decimals": 0,
+          "format": "s",
+          "logBase": 1,
+          "max": null,
+          "min": "0",
+          "show": true,
+          "splitFactor": null
+        },
+        "yBucketBound": "auto",
+        "yBucketNumber": null,
+        "yBucketSize": null
+      },
+      {
+        "aliasColors": {},
+        "bars": false,
+        "dashLength": 10,
+        "dashes": false,
+        "datasource": "RmZEr52nz",
+        "decimals": null,
+        "fill": 1,
+        "fillGradient": 0,
+        "gridPos": {
+          "h": 10,
+          "w": 12,
+          "x": 12,
+          "y": 0
+        },
+        "id": 4,
+        "legend": {
+          "alignAsTable": true,
+          "avg": false,
+          "current": true,
+          "max": false,
+          "min": false,
+          "rightSide": false,
+          "show": true,
+          "total": false,
+          "values": true
+        },
+        "lines": true,
+        "linewidth": 1,
+        "nullPointMode": "null",
+        "options": {
+          "dataLinks": []
+        },
+        "percentage": false,
+        "pointradius": 2,
+        "points": false,
+        "renderer": "flot",
+        "seriesOverrides": [
+          {
+            "alias": "Count",
+            "dashes": true,
+            "fill": 0,
+            "yaxis": 2
+          }
+        ],
+        "spaceLength": 10,
+        "stack": false,
+        "steppedLine": false,
+        "targets": [
+          {
+            "expr": "(smokeping_requests_total{host=\"$target\"} - smokeping_response_duration_seconds_count{host=\"$target\"})/smokeping_requests_total{host=\"$target\"} ",
+            "legendFormat": "Percentage",
+            "refId": "A"
+          },
+          {
+            "expr": "(smokeping_requests_total{host=\"$target\"} - smokeping_response_duration_seconds_count{host=\"$target\"})",
+            "legendFormat": "Count",
+            "refId": "B"
+          }
+        ],
+        "thresholds": [],
+        "timeFrom": null,
+        "timeRegions": [],
+        "timeShift": null,
+        "title": "Packet Loss - $target",
+        "tooltip": {
+          "shared": true,
+          "sort": 0,
+          "value_type": "individual"
+        },
+        "type": "graph",
+        "xaxis": {
+          "buckets": null,
+          "mode": "time",
+          "name": null,
+          "show": true,
+          "values": []
+        },
+        "yaxes": [
+          {
+            "format": "percentunit",
+            "label": "Loss %",
+            "logBase": 1,
+            "max": null,
+            "min": null,
+            "show": true
+          },
+          {
+            "decimals": 0,
+            "format": "none",
+            "label": "Loss Packet",
+            "logBase": 1,
+            "max": null,
+            "min": null,
+            "show": true
+          }
+        ],
+        "yaxis": {
+          "align": false,
+          "alignLevel": null
+        }
+      },
+      {
+        "aliasColors": {},
+        "bars": false,
+        "dashLength": 10,
+        "dashes": false,
+        "datasource": "RmZEr52nz",
+        "decimals": null,
+        "fill": 1,
+        "fillGradient": 0,
+        "gridPos": {
+          "h": 10,
+          "w": 24,
+          "x": 0,
+          "y": 10
+        },
+        "id": 5,
+        "legend": {
+          "alignAsTable": true,
+          "avg": true,
+          "current": true,
+          "max": true,
+          "min": true,
+          "rightSide": false,
+          "show": true,
+          "total": false,
+          "values": true
+        },
+        "lines": true,
+        "linewidth": 1,
+        "nullPointMode": "null",
+        "options": {
+          "dataLinks": []
+        },
+        "percentage": false,
+        "pointradius": 2,
+        "points": false,
+        "renderer": "flot",
+        "seriesOverrides": [
+          {
+            "alias": "Count",
+            "dashes": true,
+            "fill": 0,
+            "yaxis": 2
+          }
+        ],
+        "spaceLength": 10,
+        "stack": false,
+        "steppedLine": false,
+        "targets": [
+          {
+            "expr": "smokeping_response_duration_seconds_sum{host=\"$target\"} / smokeping_response_duration_seconds_count{host=\"$target\"}",
+            "legendFormat": "{{host}}",
+            "refId": "A"
+          }
+        ],
+        "thresholds": [],
+        "timeFrom": null,
+        "timeRegions": [],
+        "timeShift": null,
+        "title": "Latency - $target",
+        "tooltip": {
+          "shared": true,
+          "sort": 0,
+          "value_type": "individual"
+        },
+        "type": "graph",
+        "xaxis": {
+          "buckets": null,
+          "mode": "time",
+          "name": null,
+          "show": true,
+          "values": []
+        },
+        "yaxes": [
+          {
+            "decimals": null,
+            "format": "s",
+            "label": "",
+            "logBase": 1,
+            "max": null,
+            "min": null,
+            "show": true
+          },
+          {
+            "decimals": 0,
+            "format": "none",
+            "label": "Loss Packet",
+            "logBase": 1,
+            "max": null,
+            "min": null,
+            "show": false
+          }
+        ],
+        "yaxis": {
+          "align": false,
+          "alignLevel": null
+        }
+      }
+    ],
+    "refresh": "30s",
+    "schemaVersion": 20,
+    "style": "dark",
+    "tags": [],
+    "templating": {
+      "list": [
+        {
+          "allValue": null,
+          "current": {},
+          "datasource": "RmZEr52nz",
+          "definition": "label_values(smokeping_response_duration_seconds_bucket, host)",
+          "hide": 0,
+          "includeAll": false,
+          "label": null,
+          "multi": false,
+          "name": "target",
+          "options": [],
+          "query": "label_values(smokeping_response_duration_seconds_bucket, host)",
+          "refresh": 1,
+          "regex": "",
+          "skipUrlSync": false,
+          "sort": 1,
+          "tagValuesQuery": "",
+          "tags": [],
+          "tagsQuery": "",
+          "type": "query",
+          "useTags": false
+        }
+      ]
+    },
+    "time": {
+      "from": "now-30m",
+      "to": "now"
+    },
+    "timepicker": {
+      "refresh_intervals": [
+        "5s",
+        "10s",
+        "30s",
+        "1m",
+        "5m",
+        "15m",
+        "30m",
+        "1h",
+        "2h",
+        "1d"
+      ],
+      "time_options": [
+        "5m",
+        "15m",
+        "1h",
+        "6h",
+        "12h",
+        "24h",
+        "2d",
+        "7d",
+        "30d"
+      ]
+    },
+    "timezone": "",
+    "title": "Smoke Ping",
+    "uid": "i5aRaLaik",
+    "version": 1
+  },
+  "meta": {
+    "annotationsPermissions": {
+      "dashboard": {
+        "canAdd": true,
+        "canDelete": true,
+        "canEdit": true
+      },
+      "organization": {
+        "canAdd": true,
+        "canDelete": true,
+        "canEdit": true
+      }
+    },
+    "canAdmin": true,
+    "canDelete": true,
+    "canEdit": true,
+    "canSave": true,
+    "canStar": true,
+    "createdBy": "admin",
+    "expires": "0001-01-01T00:00:00Z",
+    "folderTitle": "ops",
+    "hasAcl": false,
+    "isFolder": false,
+    "provisioned": false,
+    "provisionedExternalId": "",
+    "publicDashboardAccessToken": "",
+    "publicDashboardEnabled": false,
+    "publicDashboardUid": "",
+    "slug": "smoke-ping",
+    "type": "db",
+    "updatedBy": "admin",
+    "url": "/grafana/d/i5aRaLaik/smoke-ping"
+  }
+}

--- a/services/monitoring/smokeping_prober_config.yaml
+++ b/services/monitoring/smokeping_prober_config.yaml
@@ -8,7 +8,7 @@ targets:
   - google.com
   - facebook.com
   - osparc-master.speag.com
-  - smtp.osparc.io #Only here w eaccet ICMP for pinging
+  - smtp.osparc.io # Hacky: This accepts ICMP for pinging, as this DNS name resolves to an EC2 instance directly, unlike the load-balanced https://osparc.io .
   interval: 1s # Duration, Default 1s.
   network: ip # One of ip, ip4, ip6. Default: ip (automatic IPv4/IPv6)
   protocol: icmp # One of icmp, udp. Default: icmp (Requires privileged operation)

--- a/services/monitoring/smokeping_prober_config.yaml
+++ b/services/monitoring/smokeping_prober_config.yaml
@@ -1,0 +1,16 @@
+---
+targets:
+- hosts:
+  - osparc.speag.com
+  - tip.itis.swiss
+  - speag.com
+  - itis.swiss
+  - google.com
+  - facebook.com
+  - osparc-master.speag.com
+  - smtp.osparc.io #Only here w eaccet ICMP for pinging
+  interval: 1s # Duration, Default 1s.
+  network: ip # One of ip, ip4, ip6. Default: ip (automatic IPv4/IPv6)
+  protocol: icmp # One of icmp, udp. Default: icmp (Requires privileged operation)
+  size: 56 # Packet data size in bytes. Default 56 (Range: 24 - 65535)
+# via https://github.com/SuperQ/smokeping_prober


### PR DESCRIPTION
FYI: Adding @mguidon and @matusdrobuliak66 since they might soon work with prometheus or expose metrics to prometheus, so they might find this interesting.

=======================================

This PR addresses https://git.speag.com/oSparc/osparc-ops-environments/-/issues/581 . 

This PR adds:
- Smokeping-Prober Prometheus Exporter https://github.com/SuperQ/smokeping_prober
- Smokeping Grafana Dashboard https://grafana.com/grafana/dashboards/11335-smoke-ping/

The Smokeping dashboard can be used to visualize package drops, package timeouts and networking delays.

In the current configuration, the smokeping-prober will ping (thus via ICMP, not UDP/TCP) the following machines every second and export the timings and whether the ping has been successful to a `/metrics` route which is scraped by prometheus automagically:
- tip.itis.swiss
- osparc-master.speag.com
- osparc.speag.com
- facebook.com
- google.com
- speag.com
- smpt.osparc.io (the ELB loadbalancer of aws which routes `https://osparc.io` does not accept the ICMP protocol, thus we abuse `smtp.osparc.io` to directly go to the manager01 machine of osparc.io)



This is what the grafana dashboard looks like:
![image](https://github.com/ITISFoundation/osparc-ops-environments/assets/8209087/3bddc649-32e5-45d6-9772-396e1becb781)





🚧🚧🚧:
I am not sure that this will work out of the box on all deployments, as I cannot be sure at this point that for example on aws all machines can reach `osparc.speag.com` (due to wireguard, etc.). I guess we will have a look when releasing and adjust accordingly.

Also, since we dont have GitOps yet, these changes to the `monitoring` docker swarm stack need to be rolled out to staging/prod manually.
