### PR TITLE
Remove graylog alert that is not accurate / does not apply anymore

### DIFF
--- a/services/graylog/scripts/alerts.template.yaml
+++ b/services/graylog/scripts/alerts.template.yaml
@@ -232,45 +232,6 @@
     grace_period_ms: 0
     backlog_size: 99
   alert: true
-- title: "${MACHINE_FQDN}: CRITICAL director-v2 error. Plattform operations impaired. Director-v2 restart required."
-  description: "${MACHINE_FQDN}: CRITICAL director-v2 error. Plattform operations impaired. Director-v2 restart required."
-  priority: 3
-  config:
-    query: >
-      container_name: /.*director-v2.*/ AND ":e=PoolTimeout('')" AND NOT container_name:/.*graylog_graylog.*/
-    query_parameters: []
-    search_within_ms: 600000
-    execute_every_ms: 600000
-    group_by: []
-    series: []
-    conditions: {}
-    type: aggregation-v1
-  field_spec:
-    source:
-      data_type: string
-      providers:
-      - type: template-v1
-        template: "${source.source}"
-        require_values: false
-    container_name:
-      data_type: string
-      providers:
-      - type: template-v1
-        template: "${source.container_name}"
-        require_values: false
-    full_message:
-      data_type: string
-      providers:
-      - type: template-v1
-        template: "${source.full_message}"
-  key_spec:
-    - source
-    - container_name
-    - full_message
-  notification_settings:
-    grace_period_ms: 0
-    backlog_size: 99
-  alert: true
 - title: "${MACHINE_FQDN}: DOCKER IP POOL EXHAUSTED, no service can start"
   description: "${MACHINE_FQDN}: DOCKER IP POOL EXHAUSTED, no service can start. See: https://github.com/moby/moby/issues/30820"
   priority: 3


### PR DESCRIPTION
As said, we discussed this with @GitHK 