### PR TITLE
Adds second prometheus

### DIFF
--- a/services/monitoring/docker-compose.aws.yml
+++ b/services/monitoring/docker-compose.aws.yml
@@ -1,6 +1,6 @@
 version: "3.7"
 services:
-  prometheus:
+  prometheus-catchall:
     dns: 8.8.8.8
     deploy:
       placement:
@@ -11,6 +11,17 @@ services:
           memory: 24576M
         reservations:
           memory: 24576M
+  prometheus-cadvisor:
+    dns: 8.8.8.8
+    deploy:
+      placement:
+        constraints:
+          - node.labels.prometheus==true
+      resources:
+        limits:
+          memory: 4096M
+        reservations:
+          memory: 4096M
   grafana:
     dns: 8.8.8.8
     deploy:

--- a/services/monitoring/docker-compose.dalco.yml
+++ b/services/monitoring/docker-compose.dalco.yml
@@ -14,7 +14,12 @@ services:
         constraints:
           - node.labels.grafana==true
 
-  prometheus:
+  prometheus-catchall:
+    deploy:
+      placement:
+        constraints:
+          - node.labels.prometheus==true
+  prometheus-cadvisor:
     deploy:
       placement:
         constraints:

--- a/services/monitoring/docker-compose.letsencrypt.dns.yml
+++ b/services/monitoring/docker-compose.letsencrypt.dns.yml
@@ -1,6 +1,6 @@
 version: "3.7"
 services:
-  prometheus:
+  prometheus-catchall:
     deploy:
       labels:
         - traefik.http.routers.prometheus.tls.certresolver=myresolver
@@ -9,3 +9,8 @@ services:
     deploy:
       labels:
         - traefik.http.routers.grafana.tls.certresolver=myresolver
+
+  prometheus-cadvisor:
+    deploy:
+      labels:
+        - traefik.http.routers.prometheus.tls.certresolver=myresolver

--- a/services/monitoring/docker-compose.letsencrypt.http.yml
+++ b/services/monitoring/docker-compose.letsencrypt.http.yml
@@ -1,11 +1,15 @@
 version: "3.7"
 services:
-  prometheus:
+  prometheus-catchall:
     deploy:
       labels:
         - traefik.http.routers.prometheus.tls.certresolver=lehttpchallenge
-
   grafana:
     deploy:
       labels:
         - traefik.http.routers.grafana.tls.certresolver=lehttpchallenge
+  prometheus-cadvisor:
+    deploy:
+      placement:
+        constraints:
+          - traefik.http.routers.prometheus.tls.certresolver=lehttpchallenge

--- a/services/monitoring/docker-compose.master.yml
+++ b/services/monitoring/docker-compose.master.yml
@@ -5,7 +5,12 @@ services:
       placement:
         constraints:
           - node.labels.grafana==true
-  prometheus:
+  prometheus-catchall:
+    deploy:
+      placement:
+        constraints:
+          - node.labels.prometheus==true
+  prometheus-cadvisor:
     deploy:
       placement:
         constraints:

--- a/services/monitoring/docker-compose.yml.j2
+++ b/services/monitoring/docker-compose.yml.j2
@@ -4,6 +4,7 @@ volumes:
   prometheus_data: {}
   grafana_data: {}
   alertmanager_data: {}
+  prometheus_data_cadvisor: {}
 
 networks:
   internal:
@@ -22,6 +23,8 @@ configs:
   node_exporter_entrypoint:
     file: ./node-exporter/docker-entrypoint.sh
   prometheus_config:
+    file: ./prometheus/prometheus.yml
+  prometheus_config_cadvisor:
     file: ./prometheus/prometheus.yml
   prometheus_rules:
     file: ./prometheus/prometheus.rules.yml
@@ -76,21 +79,21 @@ services:
           memory: 4096M
         reservations:
           memory: 4096M
-prometheus-cadvisor:
-  image: prom/prometheus:v2.44.0
+  prometheus-cadvisor:
+    image: prom/prometheus:v2.44.0
     volumes:
       - prometheus_data_cadvisor:/prometheus
       - /var/run/docker.sock:/var/run/docker.sock:ro
     user: root # only user root can use the docker socket
     configs:
-      - source: prometheus_config
-        target: /etc/prometheus/prometheus-cadvisor.yml
+      - source: prometheus_config_cadvisor
+        target: /etc/prometheus/prometheus.yml
       - source: prometheus_rules
         target: /etc/prometheus/prometheus.rules.yml
     command:
       - "--config.file=/etc/prometheus/prometheus.yml"
       - "--storage.tsdb.path=/prometheus"
-      - "--storage.tsdb.retention=30"
+      - "--storage.tsdb.retention=30d"
       - "--web.console.libraries=/usr/share/prometheus/console_libraries"
       - "--web.console.templates=/usr/share/prometheus/consoles"
       - "--web.external-url=https://${MONITORING_DOMAIN}/prometheus-cadvisor/"
@@ -107,12 +110,12 @@ prometheus-cadvisor:
         - traefik.enable=true
         - traefik.docker.network=${PUBLIC_NETWORK}
         # direct access through port
-        - traefik.http.services.prometheus.loadbalancer.server.port=${MONITORING_PROMETHEUS_PORT}
-        - traefik.http.routers.prometheus.rule=Host(`${MONITORING_DOMAIN}`) && PathPrefix(`/prometheus-cadvisor`)
-        - traefik.http.routers.prometheus.entrypoints=https
-        - traefik.http.routers.prometheus.tls=true
-        - traefik.http.middlewares.prometheus_stripprefixregex.stripprefixregex.regex=^/prometheus
-        - traefik.http.routers.prometheus.middlewares=ops_whitelist_ips@docker, ops_auth@docker, ops_gzip@docker, prometheus_stripprefixregex
+        - traefik.http.services.prometheuscadvisor.loadbalancer.server.port=${MONITORING_PROMETHEUS_PORT}
+        - traefik.http.routers.prometheuscadvisor.rule=Host(`${MONITORING_DOMAIN}`) && PathPrefix(`/prometheuscadvisor`)
+        - traefik.http.routers.prometheuscadvisor.entrypoints=https
+        - traefik.http.routers.prometheuscadvisor.tls=true
+        - traefik.http.middlewares.prometheuscadvisor_stripprefixregex.stripprefixregex.regex=^/prometheuscadvisor
+        - traefik.http.routers.prometheuscadvisor.middlewares=ops_whitelist_ips@docker, ops_auth@docker, ops_gzip@docker, prometheuscadvisor_stripprefixregex
         - prometheus-job=prometheus-cadvisor
         - prometheus-port=${MONITORING_PROMETHEUS_PORT}
       resources:
@@ -120,7 +123,6 @@ prometheus-cadvisor:
           memory: 4096M
         reservations:
           memory: 4096M
-
   node-exporter:
     image: prom/node-exporter:v0.18.1
     volumes:

--- a/services/monitoring/docker-compose.yml.j2
+++ b/services/monitoring/docker-compose.yml.j2
@@ -25,7 +25,7 @@ configs:
   prometheus_config:
     file: ./prometheus/prometheus.yml
   prometheus_config_cadvisor:
-    file: ./prometheus/prometheus.yml
+    file: ./prometheus/prometheus-cadvisor.yml
   prometheus_rules:
     file: ./prometheus/prometheus.rules.yml
   grafana_image_renderer_config:
@@ -36,6 +36,7 @@ configs:
     file: ./smokeping_prober_config.yaml
 services:
   prometheus-catchall:
+    hostname: "{% raw %}{{.Service.Name}}{% endraw %}"
     image: prom/prometheus:v2.44.0
     volumes:
       - prometheus_data:/prometheus
@@ -66,12 +67,12 @@ services:
         - traefik.enable=true
         - traefik.docker.network=${PUBLIC_NETWORK}
         # direct access through port
-        - traefik.http.services.prometheus.loadbalancer.server.port=${MONITORING_PROMETHEUS_PORT}
-        - traefik.http.routers.prometheus.rule=Host(`${MONITORING_DOMAIN}`) && PathPrefix(`/prometheus`)
-        - traefik.http.routers.prometheus.entrypoints=https
-        - traefik.http.routers.prometheus.tls=true
-        - traefik.http.middlewares.prometheus_stripprefixregex.stripprefixregex.regex=^/prometheus
-        - traefik.http.routers.prometheus.middlewares=ops_whitelist_ips@docker, ops_auth@docker, ops_gzip@docker, prometheus_stripprefixregex
+        - traefik.http.services.prometheuscatchall.loadbalancer.server.port=${MONITORING_PROMETHEUS_PORT}
+        - traefik.http.routers.prometheuscatchall.rule=Host(`${MONITORING_DOMAIN}`) && PathPrefix(`/prometheus`)
+        - traefik.http.routers.prometheuscatchall.entrypoints=https
+        - traefik.http.routers.prometheuscatchall.tls=true
+        - traefik.http.middlewares.prometheuscatchall_stripprefixregex.stripprefixregex.regex=^/prometheus
+        - traefik.http.routers.prometheuscatchall.middlewares=ops_whitelist_ips@docker, ops_auth@docker, ops_gzip@docker, prometheuscatchall_stripprefixregex
         - prometheus-job=prometheus-catchall
         - prometheus-port=${MONITORING_PROMETHEUS_PORT}
       resources:
@@ -80,6 +81,7 @@ services:
         reservations:
           memory: 4096M
   prometheus-cadvisor:
+    hostname: "{% raw %}{{.Service.Name}}{% endraw %}"
     image: prom/prometheus:v2.44.0
     volumes:
       - prometheus_data_cadvisor:/prometheus
@@ -202,7 +204,7 @@ services:
           memory: 64M
 
   cadvisor-exporter:
-    image: gcr.io/cadvisor/cadvisor:v0.46.0
+    image: gcr.io/cadvisor/cadvisor:v0.47.0
     volumes:
       - /:/rootfs:ro
       - /var/run:/var/run:ro

--- a/services/monitoring/docker-compose.yml.j2
+++ b/services/monitoring/docker-compose.yml.j2
@@ -32,8 +32,8 @@ configs:
   smokeping_prober_config:
     file: ./smokeping_prober_config.yaml
 services:
-  prometheus:
-    image: prom/prometheus:v2.40.7
+  prometheus-catchall:
+    image: prom/prometheus:v2.44.0
     volumes:
       - prometheus_data:/prometheus
       - /var/run/docker.sock:/var/run/docker.sock:ro
@@ -69,13 +69,57 @@ services:
         - traefik.http.routers.prometheus.tls=true
         - traefik.http.middlewares.prometheus_stripprefixregex.stripprefixregex.regex=^/prometheus
         - traefik.http.routers.prometheus.middlewares=ops_whitelist_ips@docker, ops_auth@docker, ops_gzip@docker, prometheus_stripprefixregex
-        - prometheus-job=prometheus
+        - prometheus-job=prometheus-catchall
         - prometheus-port=${MONITORING_PROMETHEUS_PORT}
       resources:
         limits:
           memory: 4096M
         reservations:
-          memory: 64M
+          memory: 4096M
+prometheus-cadvisor:
+  image: prom/prometheus:v2.44.0
+    volumes:
+      - prometheus_data_cadvisor:/prometheus
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+    user: root # only user root can use the docker socket
+    configs:
+      - source: prometheus_config
+        target: /etc/prometheus/prometheus-cadvisor.yml
+      - source: prometheus_rules
+        target: /etc/prometheus/prometheus.rules.yml
+    command:
+      - "--config.file=/etc/prometheus/prometheus.yml"
+      - "--storage.tsdb.path=/prometheus"
+      - "--storage.tsdb.retention=30"
+      - "--web.console.libraries=/usr/share/prometheus/console_libraries"
+      - "--web.console.templates=/usr/share/prometheus/consoles"
+      - "--web.external-url=https://${MONITORING_DOMAIN}/prometheus-cadvisor/"
+      - "--web.route-prefix=/"
+      - "--storage.tsdb.allow-overlapping-blocks" # via https://jessicagreben.medium.com/prometheus-fill-in-data-for-new-recording-rules-30a14ccb8467
+      #- "--web.enable-admin-api" This allows messing with prometheus using its API from the CLI. Disabled for security reasons by default.
+    networks:
+      - internal
+      - monitored
+      - public
+    extra_hosts: []
+    deploy:
+      labels:
+        - traefik.enable=true
+        - traefik.docker.network=${PUBLIC_NETWORK}
+        # direct access through port
+        - traefik.http.services.prometheus.loadbalancer.server.port=${MONITORING_PROMETHEUS_PORT}
+        - traefik.http.routers.prometheus.rule=Host(`${MONITORING_DOMAIN}`) && PathPrefix(`/prometheus-cadvisor`)
+        - traefik.http.routers.prometheus.entrypoints=https
+        - traefik.http.routers.prometheus.tls=true
+        - traefik.http.middlewares.prometheus_stripprefixregex.stripprefixregex.regex=^/prometheus
+        - traefik.http.routers.prometheus.middlewares=ops_whitelist_ips@docker, ops_auth@docker, ops_gzip@docker, prometheus_stripprefixregex
+        - prometheus-job=prometheus-cadvisor
+        - prometheus-port=${MONITORING_PROMETHEUS_PORT}
+      resources:
+        limits:
+          memory: 4096M
+        reservations:
+          memory: 4096M
 
   node-exporter:
     image: prom/node-exporter:v0.18.1

--- a/services/monitoring/prometheus/prometheus-cadvisor.yml
+++ b/services/monitoring/prometheus/prometheus-cadvisor.yml
@@ -1,0 +1,83 @@
+#  global config
+#  DOLLAR SIGNS NEED TO BE EXCAPED (see https://stackoverflow.com/a/61259844/10198629)
+global:
+  scrape_interval: 16s # By default, scrape targets every 15 seconds.
+  evaluation_interval: 16s # By default, scrape targets every 15 seconds.
+  # scrape_timeout global default would be (10s).
+
+  # Attach these labels to any time series or alerts when communicating with
+  # external systems (federation, remote storage, Alertmanager).
+  external_labels:
+    monitor: "sim-core-monitor"
+
+# A scrape configuration containing exactly one endpoint to scrape:
+scrape_configs:
+  # The job name is added as a label `job=<job_name>` to any timeseries scraped from this config.
+
+  # Create a job for Docker daemons. see [https://prometheus.io/docs/guides/dockerswarm/]
+
+  # Create a job for Docker Swarm containers.
+  # Prometheus docker swarm discovery will automatically discover services that need to be scraped by prometheus
+  # All services that need to be monitored must at least define the following SERVICE labels (in deploy/labels section):
+  # deploy:
+  #   labels:
+  #     # prometheus labels
+  #     - prometheus-job=traefik_ops
+  #     - prometheus-port=8082
+  #
+  - job_name: "dockerswarm-tasks"
+    dockerswarm_sd_configs:
+      - host: unix:///var/run/docker.sock
+        role: tasks # this scrapes docker tasks
+    relabel_configs:
+      # keep only metrics that are available over monitored network
+      - source_labels: [__meta_dockerswarm_network_name]
+        regex: ${MONITORED_NETWORK}
+        action: keep
+      # Only keep containers that should be running
+      - source_labels: [__meta_dockerswarm_task_desired_state]
+        regex: running
+        action: keep
+      # Only keep containers that have a `prometheus-job` label.
+      - source_labels: [__meta_dockerswarm_service_label_prometheus_job]
+        regex: cadvisor
+        action: keep
+      # Keep the containers IP and Port, very necessary for our setup DONT MESS WITH THIS
+      - source_labels:
+          [__address__, __meta_dockerswarm_service_label_prometheus_port]
+        separator: ";"
+        regex: "(.*):.*;(.*)"
+        target_label: __address__
+        replacement: $${empty_var}1:$${empty_var}2
+      #
+      # Use the prometheus-port Swarm label as Prometheus job port.
+      - source_labels: [__meta_dockerswarm_service_label_prometheus_job]
+        target_label: job
+      # Set hostname as instance label
+      - source_labels: [__meta_dockerswarm_node_hostname]
+        target_label: instance
+    metric_relabel_configs:
+      - regex: "container_label_com_docker_compose_config_hash"
+        action: labeldrop  # cAdvisor pruning
+      - regex: "container_label_com_docker_compose_container_number"
+        action: labeldrop  # cAdvisor pruning
+      - regex: "container_label_io_simcore_.*"
+        action: labeldrop  # cAdvisor pruning
+      - regex: "container_label_simcore_service_compose_spec"
+        action: labeldrop  # cAdvisor pruning
+      - regex: "container_label_simcore_service_container_http_entrypoint"
+        action: labeldrop  # cAdvisor pruning
+      - regex: "container_label_simcore_service_paths_mapping"
+        action: labeldrop  # cAdvisor pruning
+      - regex: "container_label_org_.*"
+        action: labeldrop  # cAdvisor pruning
+      - regex: "container_label_com_docker_compose_project"
+        action: labeldrop  # cAdvisor pruning
+      - regex: "container_label_com_docker_compose_project_config_files"
+        action: labeldrop  # cAdvisor pruning
+      - regex: "container_label_com_docker_compose_service"
+        action: labeldrop  # cAdvisor pruning
+      - regex: "container_label_com_docker_compose_project"
+        action: labeldrop  # cAdvisor pruning
+      - regex: "container_label_maintainer"
+        action: labeldrop  # cAdvisor pruning

--- a/services/monitoring/prometheus/prometheus-cadvisor.yml
+++ b/services/monitoring/prometheus/prometheus-cadvisor.yml
@@ -30,10 +30,6 @@ scrape_configs:
       - host: unix:///var/run/docker.sock
         role: tasks # this scrapes docker tasks
     relabel_configs:
-      # keep only metrics that are available over monitored network
-      - source_labels: [__meta_dockerswarm_network_name]
-        regex: ${MONITORED_NETWORK}
-        action: keep
       # Only keep containers that should be running
       - source_labels: [__meta_dockerswarm_task_desired_state]
         regex: running
@@ -48,8 +44,7 @@ scrape_configs:
         separator: ";"
         regex: "(.*):.*;(.*)"
         target_label: __address__
-        replacement: $${empty_var}1:$${empty_var}2
-      #
+        replacement: $1:$2
       # Use the prometheus-port Swarm label as Prometheus job port.
       - source_labels: [__meta_dockerswarm_service_label_prometheus_job]
         target_label: job


### PR DESCRIPTION
Adds a prometheus specifically for tracking cAdvisor metrics for 30 days.

This is functional, and doesn't interfere with the current "regular" Prometheus.

The prometheus is exposed at `monitoring.osparc.local/prometheuscadvisor`