### PR TITLE
Add prometheus cAdvisor placement label for second prometheus

### DIFF
--- a/services/monitoring/docker-compose.aws.yml
+++ b/services/monitoring/docker-compose.aws.yml
@@ -16,7 +16,7 @@ services:
     deploy:
       placement:
         constraints:
-          - node.labels.prometheus==true
+          - node.labels.prometheuscadvisor==true
       resources:
         limits:
           memory: 4096M

--- a/services/monitoring/grafana/provisioning/allDeployments/datasources/1.json
+++ b/services/monitoring/grafana/provisioning/allDeployments/datasources/1.json
@@ -19,7 +19,7 @@
   "type": "prometheus",
   "typeLogoUrl": "",
   "uid": "RmZEr52nz",
-  "url": "http://prometheus:9090",
+  "url": "http://prometheus-catchall:9090",
   "user": "",
   "version": 1,
   "withCredentials": false


### PR DESCRIPTION
Places cadvisor-prometheus on a second ops machine on aws-prod with a new docker placement label `prometheuscadvisor`.

For this, a new machine needs to be added to the aws-prod cluster / swarm.

This goes with the following osparc-infra PR: `https://git.speag.com/oSparc/osparc-infra/-/merge_requests/138`



Bonus:
- Fixes grafana prometheus datasource