### PR TITLE
🐛 ⚗️ Faulty prometheus instance names not corresponding to hostnames

### DIFF
--- a/services/monitoring/prometheus/README.md
+++ b/services/monitoring/prometheus/README.md
@@ -10,3 +10,6 @@
 #### Tricks and Tips:
 Fill in past data for new rules (make sure to backup data before)
 - https://jessicagreben.medium.com/prometheus-fill-in-data-for-new-recording-rules-30a14ccb8467
+
+This is a useful tool to check prometheus service discovery and relabeling rules:
+https://relabeler.promlabs.com/

--- a/services/monitoring/prometheus/prometheus-base.yml
+++ b/services/monitoring/prometheus/prometheus-base.yml
@@ -37,6 +37,8 @@ scrape_configs:
       - source_labels: [__meta_dockerswarm_node_address]
         target_label: __address__
         replacement: $${empty_var}1:9323
+      - source_labels: [__meta_dockerswarm_node_hostname]
+        target_label: instance
       # Set hostname as instance label
       # Swarm manager give the address 0.0.0.0 and is then not scraped by Prometheus. Fixed thansk to https://github.com/prometheus/prometheus/issues/11060#issuecomment-1195278301
       - source_labels:


### PR DESCRIPTION
This tries to fix the bug/incident describes here: 
- https://github.com/ITISFoundation/osparc-ops-environments/pull/150#issuecomment-1602645260
- https://git.speag.com/oSparc/osparc-infra/-/issues/26

The issue was most likely introduced in https://github.com/ITISFoundation/osparc-ops-environments/pull/150