### PR TITLE
🐛 Fix 302 Redirect bug in cadvisor prometheus

### DIFF
--- a/services/monitoring/docker-compose.aws.yml
+++ b/services/monitoring/docker-compose.aws.yml
@@ -1,6 +1,6 @@
 version: "3.7"
 services:
-  prometheus-catchall:
+  prometheuscatchall:
     dns: 8.8.8.8
     deploy:
       placement:
@@ -11,7 +11,7 @@ services:
           memory: 24576M
         reservations:
           memory: 24576M
-  prometheus-cadvisor:
+  prometheuscadvisor:
     dns: 8.8.8.8
     deploy:
       placement:

--- a/services/monitoring/docker-compose.dalco.yml
+++ b/services/monitoring/docker-compose.dalco.yml
@@ -14,12 +14,12 @@ services:
         constraints:
           - node.labels.grafana==true
 
-  prometheus-catchall:
+  prometheuscatchall:
     deploy:
       placement:
         constraints:
           - node.labels.prometheus==true
-  prometheus-cadvisor:
+  prometheuscadvisor:
     deploy:
       placement:
         constraints:

--- a/services/monitoring/docker-compose.letsencrypt.dns.yml
+++ b/services/monitoring/docker-compose.letsencrypt.dns.yml
@@ -1,6 +1,6 @@
 version: "3.7"
 services:
-  prometheus-catchall:
+  prometheuscatchall:
     deploy:
       labels:
         - traefik.http.routers.prometheus.tls.certresolver=myresolver
@@ -10,7 +10,7 @@ services:
       labels:
         - traefik.http.routers.grafana.tls.certresolver=myresolver
 
-  prometheus-cadvisor:
+  prometheuscadvisor:
     deploy:
       labels:
         - traefik.http.routers.prometheus.tls.certresolver=myresolver

--- a/services/monitoring/docker-compose.letsencrypt.http.yml
+++ b/services/monitoring/docker-compose.letsencrypt.http.yml
@@ -1,6 +1,6 @@
 version: "3.7"
 services:
-  prometheus-catchall:
+  prometheuscatchall:
     deploy:
       labels:
         - traefik.http.routers.prometheus.tls.certresolver=lehttpchallenge
@@ -8,7 +8,7 @@ services:
     deploy:
       labels:
         - traefik.http.routers.grafana.tls.certresolver=lehttpchallenge
-  prometheus-cadvisor:
+  prometheuscadvisor:
     deploy:
       placement:
         constraints:

--- a/services/monitoring/docker-compose.master.yml
+++ b/services/monitoring/docker-compose.master.yml
@@ -5,12 +5,12 @@ services:
       placement:
         constraints:
           - node.labels.grafana==true
-  prometheus-catchall:
+  prometheuscatchall:
     deploy:
       placement:
         constraints:
           - node.labels.prometheus==true
-  prometheus-cadvisor:
+  prometheuscadvisor:
     deploy:
       placement:
         constraints:

--- a/services/monitoring/docker-compose.yml.j2
+++ b/services/monitoring/docker-compose.yml.j2
@@ -336,32 +336,6 @@ services:
       - prometheus-job=dcgm-exporter
       - prometheus-port=9400
 
-  s3-exporter:
-    image:  ghcr.io/traptitech/s3_exporter:latest
-    volumes: []
-    networks:
-      - internal
-      - monitored
-    extra_hosts: []
-    deploy:
-      labels: []
-      placement:
-        constraints:
-          - node.labels.prometheus==true
-      resources:
-        limits:
-          memory: 128M
-        reservations:
-          memory: 128M
-      labels:
-        - prometheus-job=s3-exporter
-        - prometheus-port=9340
-    environment:
-      - AWS_ACCESS_KEY_ID={{S3_ACCESS_KEY}}
-      - AWS_SECRET_ACCESS_KEY={{S3_SECRET_KEY}}
-      - S3_EXPORTER_S3_ENDPOINT_URL={{S3_ENDPOINT}}
-      - AWS_REGION=us-east-1
-
   pgsql-query-exporter:
     image: adonato/query-exporter:2.8.3
     volumes: []

--- a/services/monitoring/docker-compose.yml.j2
+++ b/services/monitoring/docker-compose.yml.j2
@@ -35,7 +35,7 @@ configs:
   smokeping_prober_config:
     file: ./smokeping_prober_config.yaml
 services:
-  prometheus-catchall:
+  prometheuscatchall:
     hostname: "{% raw %}{{.Service.Name}}{% endraw %}"
     image: prom/prometheus:v2.44.0
     volumes:
@@ -73,14 +73,14 @@ services:
         - traefik.http.routers.prometheuscatchall.tls=true
         - traefik.http.middlewares.prometheuscatchall_stripprefixregex.stripprefixregex.regex=^/prometheus
         - traefik.http.routers.prometheuscatchall.middlewares=ops_whitelist_ips@docker, ops_auth@docker, ops_gzip@docker, prometheuscatchall_stripprefixregex
-        - prometheus-job=prometheus-catchall
+        - prometheus-job=prometheuscatchall
         - prometheus-port=${MONITORING_PROMETHEUS_PORT}
       resources:
         limits:
           memory: 4096M
         reservations:
           memory: 4096M
-  prometheus-cadvisor:
+  prometheuscadvisor:
     hostname: "{% raw %}{{.Service.Name}}{% endraw %}"
     image: prom/prometheus:v2.44.0
     volumes:
@@ -98,7 +98,7 @@ services:
       - "--storage.tsdb.retention=30d"
       - "--web.console.libraries=/usr/share/prometheus/console_libraries"
       - "--web.console.templates=/usr/share/prometheus/consoles"
-      - "--web.external-url=https://${MONITORING_DOMAIN}/prometheus-cadvisor/"
+      - "--web.external-url=https://${MONITORING_DOMAIN}/prometheuscadvisor/"
       - "--web.route-prefix=/"
       - "--storage.tsdb.allow-overlapping-blocks" # via https://jessicagreben.medium.com/prometheus-fill-in-data-for-new-recording-rules-30a14ccb8467
       #- "--web.enable-admin-api" This allows messing with prometheus using its API from the CLI. Disabled for security reasons by default.
@@ -118,7 +118,7 @@ services:
         - traefik.http.routers.prometheuscadvisor.tls=true
         - traefik.http.middlewares.prometheuscadvisor_stripprefixregex.stripprefixregex.regex=^/prometheuscadvisor
         - traefik.http.routers.prometheuscadvisor.middlewares=ops_whitelist_ips@docker, ops_auth@docker, ops_gzip@docker, prometheuscadvisor_stripprefixregex
-        - prometheus-job=prometheus-cadvisor
+        - prometheus-job=prometheuscadvisor
         - prometheus-port=${MONITORING_PROMETHEUS_PORT}
       resources:
         limits:
@@ -335,6 +335,32 @@ services:
     labels:
       - prometheus-job=dcgm-exporter
       - prometheus-port=9400
+
+  s3-exporter:
+    image:  ghcr.io/traptitech/s3_exporter:latest
+    volumes: []
+    networks:
+      - internal
+      - monitored
+    extra_hosts: []
+    deploy:
+      labels: []
+      placement:
+        constraints:
+          - node.labels.prometheus==true
+      resources:
+        limits:
+          memory: 128M
+        reservations:
+          memory: 128M
+      labels:
+        - prometheus-job=s3-exporter
+        - prometheus-port=9340
+    environment:
+      - AWS_ACCESS_KEY_ID={{S3_ACCESS_KEY}}
+      - AWS_SECRET_ACCESS_KEY={{S3_SECRET_KEY}}
+      - S3_EXPORTER_S3_ENDPOINT_URL={{S3_ENDPOINT}}
+      - AWS_REGION=us-east-1
 
   pgsql-query-exporter:
     image: adonato/query-exporter:2.8.3


### PR DESCRIPTION
The line ` - "--web.external-url=https://${MONITORING_DOMAIN}/prometheus-cadvisor/"` was wrong.

Bonus:
Fix ambiguous naming in the two Prometheus services.