### PR TITLE
Bump migration RAM to 180MB

### DIFF
--- a/services/simcore/docker-compose.yml
+++ b/services/simcore/docker-compose.yml
@@ -433,10 +433,10 @@ services:
     deploy:
       resources:
         limits:
-          memory: 64M
+          memory: 180M
           cpus: '1.000'
         reservations:
-          memory: 64M
+          memory: 180M
   rabbit:
     networks:
       - monitored


### PR DESCRIPTION
Follow Up: https://github.com/ITISFoundation/osparc-simcore/pull/4418#issuecomment-1604529841