### PR TITLE
Fixes redis-commander wrong CMD on hotfix v1.56.1

### DIFF
--- a/services/redis-commander/docker-compose.dalco.yml
+++ b/services/redis-commander/docker-compose.dalco.yml
@@ -2,7 +2,7 @@ version: '3.7'
 services:
   redis-commander:
     environment:
-      REDIS_HOSTS: "production_resources:production_redis:${REDIS_PORT}:0,production_locks:production_redis:${REDIS_PORT}:1,production_validation_codes:production_redis:${REDIS_PORT}:2,production_scheduled_maintenance:production_redis:${REDIS_PORT}:3,production_user_notifications:production_redis:${REDIS_PORT}:4,production_announcements:production_redis:${REDIS_PORT}:5,staging_resources:staging_redis:${REDIS_PORT}:0,staging_locks:staging_redis:${REDIS_PORT}:1,staging_validation_codes:staging_redis:${REDIS_PORT}:2,staging_scheduled_maintenance:staging_redis:${REDIS_PORT}:3,staging_user_notifications:staging_redis:${REDIS_PORT}:4,staging_announcements:staging_redis:${REDIS_PORT}:5"
+      REDIS_HOSTS: "production_resources:production_redis:${REDIS_PORT}:0,production_locks:production_redis:${REDIS_PORT}:1,production_validation_codes:production_redis:${REDIS_PORT}:2,production_scheduled_maintenance:production_redis:${REDIS_PORT}:3,production_user_notifications:production_redis:${REDIS_PORT}:4,production_announcements:production_redis:${REDIS_PORT}:5,staging_resources:staging_redis:${REDIS_PORT}:0,staging_locks:staging_redis:${REDIS_PORT}:1,staging_validation_codes:staging_redis:${REDIS_PORT}:2,staging_scheduled_maintenance:staging_redis:${REDIS_PORT}:3,staging_user_notifications:staging_redis:${REDIS_PORT}:4"
       URL_PREFIX: /redis
     deploy:
       placement:


### PR DESCRIPTION
Redis commander cannot start the service because db index is unreachable

[v1.56.1 hotfix](https://github.com/ITISFoundation/osparc-simcore/issues/4494) adds redis db index 5 in production but this index does not exists in redis deployed in staging (since it is hotfix!). 


@mrnicegyu11 @YuryHrytsuk, we added this change manually in portainer for dalco. For the other deploys we wait for you to apply this change properly. thx 

TODO: I suggest to change the CMD to multiline so we can spot easier the diffs .thx