### PR TITLE
Bump DCGM Exporter RAM limit to sane level

### DIFF
--- a/services/monitoring/docker-compose.yml.j2
+++ b/services/monitoring/docker-compose.yml.j2
@@ -329,9 +329,9 @@ services:
           - node.labels.gpu==true
       resources:
         limits:
-          memory: 200M
+          memory: 350M #via trial and error test on tip-deployment DK Aug2023
         reservations:
-          memory: 200M
+          memory: 350M #via trial and error test on tip-deployment DK Aug2023
     labels:
       - prometheus-job=dcgm-exporter
       - prometheus-port=9400


### PR DESCRIPTION
This was tested with trial-and-error and looking at Prometheus statistics on the tip-deployment. I hope the value translates to dalco and the aws cloud as well:

![image](https://github.com/ITISFoundation/osparc-ops-environments/assets/8209087/58e5ac20-423f-4d95-8a3a-691034471352)
