### PR TITLE
⬆️ Bump Ops docker images (dependencies)

### DIFF
--- a/services/graylog/docker-compose.yml
+++ b/services/graylog/docker-compose.yml
@@ -37,7 +37,7 @@ services:
           memory: 1G
   # Graylog: https://hub.docker.com/r/graylog/graylog/
   graylog:
-    image: graylog/graylog:5.0.8
+    image: graylog/graylog:5.1.4
     init: true
     # user: "1000:1001"
     configs:

--- a/services/jaeger/docker-compose.yml
+++ b/services/jaeger/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "3.7"
 services:
   jaeger:
-    image: jaegertracing/all-in-one:1.46
+    image: jaegertracing/all-in-one:1.47
     command: >
       --query.base-path=/jaeger
     init: true

--- a/services/monitoring/docker-compose.yml.j2
+++ b/services/monitoring/docker-compose.yml.j2
@@ -37,7 +37,7 @@ configs:
 services:
   prometheuscatchall:
     hostname: "{% raw %}{{.Service.Name}}{% endraw %}"
-    image: prom/prometheus:v2.44.0
+    image: prom/prometheus:v2.46.0
     volumes:
       - prometheus_data:/prometheus
       - /var/run/docker.sock:/var/run/docker.sock:ro
@@ -82,7 +82,7 @@ services:
           memory: 4096M
   prometheuscadvisor:
     hostname: "{% raw %}{{.Service.Name}}{% endraw %}"
-    image: prom/prometheus:v2.44.0
+    image: prom/prometheus:v2.46.0
     volumes:
       - prometheus_data_cadvisor:/prometheus
       - /var/run/docker.sock:/var/run/docker.sock:ro
@@ -126,7 +126,7 @@ services:
         reservations:
           memory: 4096M
   node-exporter:
-    image: prom/node-exporter:v0.18.1
+    image: prom/node-exporter:v1.6.1
     volumes:
       - /sys:/host/sys:ro
       - /:/rootfs:ro
@@ -182,7 +182,7 @@ services:
           memory: 64M
 
   alertmanager:
-    image: prom/alertmanager:v0.20.0
+    image: prom/alertmanager:v0.25.0
     volumes:
       - alertmanager_data:/alertmanager
     command:
@@ -204,7 +204,7 @@ services:
           memory: 64M
 
   cadvisor-exporter:
-    image: gcr.io/cadvisor/cadvisor:v0.47.0
+    image: gcr.io/cadvisor/cadvisor:v0.47.2
     volumes:
       - /:/rootfs:ro
       - /var/run:/var/run:ro
@@ -245,7 +245,7 @@ services:
           memory: 64M
 
   grafana:
-    image: grafana/grafana-oss:9.5.3
+    image: grafana/grafana-oss:10.0.3
     volumes:
       - grafana_data:/var/lib/grafana
     env_file:
@@ -290,7 +290,7 @@ services:
           memory: 64M
 
   smokeping-prober-exporter:
-    image: quay.io/superq/smokeping-prober:v0.7.0
+    image: quay.io/superq/smokeping-prober:v0.7.1
     networks:
       - internal
       - monitored
@@ -359,7 +359,7 @@ services:
         reservations:
           memory: 64M{% for _stack in MONITORED_STACK_NAMES.split(",") if _stack != "" %}
   {{_stack}}-postgres-exporter:
-    image: bitnami/postgres-exporter:0.12.1
+    image: bitnami/postgres-exporter:0.13.2
     networks:
       - internal
       - monitored
@@ -375,7 +375,7 @@ services:
         reservations:
           memory: 64M
   {{_stack}}-redis-exporter:
-    image: oliver006/redis_exporter:v1.51.0-alpine
+    image: oliver006/redis_exporter:v1.52.0-alpine
     networks:
       - internal
       - monitored

--- a/services/portainer/docker-compose.yml
+++ b/services/portainer/docker-compose.yml
@@ -2,7 +2,7 @@ version: "3.7"
 
 services:
   agent:
-    image: portainer/agent:2.18.3 # Needs to match portainer-ce version
+    image: portainer/agent:2.18.4 # Needs to match portainer-ce version
     init: true
     environment:
       # REQUIRED: Should be equal to the service name prefixed by "tasks." when
@@ -21,7 +21,7 @@ services:
         constraints: [node.platform.os == linux]
 
   portainer:
-    image: portainer/portainer-ce:2.18.3
+    image: portainer/portainer-ce:2.18.4
     init: true
     command: >
       -H tcp://tasks.agent:9001 --tlsskipverify

--- a/services/redis-commander/docker-compose.yml
+++ b/services/redis-commander/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "3.7"
 services:
   redis-commander:
-    image: rediscommander/redis-commander:snyk-fix-1841981ea4b1abcbc4c13e21d5d2997d
+    image: rediscommander/redis-commander:snyk-fix-08c85f17c94a7f00df6fb21e8ea1d10d
     init: true
     ports:
       - 8081

--- a/services/traefik/docker-compose.yml.j2
+++ b/services/traefik/docker-compose.yml.j2
@@ -2,7 +2,7 @@ version: "3.7"
 
 services:
   traefik:
-    image: traefik:v2.10.3
+    image: traefik:v2.10.4
     init: true
     command:
       - "--api=true"


### PR DESCRIPTION
Major Versions:
- prometheus node exporter
- grafana

Minor Versions:
- jaeger
- prometheus
- prometheus alertmanager
- postgres-exporter
- redis_exporter

Patch Versions:
- redis-commander
- traefik
- cAdvisor
- smokeping-prober
- portainer

All major version upgrades had their changelog audited manually.