### PR TITLE
🐛 Fix wrong makefile target for graylog on osparc-master

### DIFF
--- a/services/graylog/Makefile
+++ b/services/graylog/Makefile
@@ -35,7 +35,7 @@ up-aws: .init .env ${TEMP_COMPOSE}-aws  ## Deploys graylog stack using let's enc
 	@docker stack deploy --with-registry-auth --prune --compose-file ${TEMP_COMPOSE}-aws ${STACK_NAME}
 
 .PHONY: up-master ## Deploys graylog stack for master
-up-master: up-letsencrypt-dns
+up-master: up-dalco
 
 .PHONY: up-local ## Deploys graylog stack for local deployment
 up-local: .init .env ${TEMP_COMPOSE}-local  ## Deploys graylog stack for local cluster


### PR DESCRIPTION
The makefile target for starting graylog on master was wrong. In the old code, the placement constraints for graylog, which needs a dedicated named docker volume, were missing. this fixes it