### PR TITLE
BUGFIX: Update traefik extractor pattern

### DIFF
--- a/services/graylog/data/contentpacks/osparc-custom-content-pack-v2.json
+++ b/services/graylog/data/contentpacks/osparc-custom-content-pack-v2.json
@@ -668,7 +668,7 @@
             "configuration": {
               "grok_pattern": {
                 "@type": "string",
-                "@value": "level=%{WORD:log_level} \\| time=%{TIMESTAMP_ISO8601:log_timestamp} \\| msg=%{GREEDYDATA:log_msg}"
+                "@value": "time=\"%{TIMESTAMP_ISO8601:log_timestamp}\" level=%{WORD:log_level} msg=\"%{GREEDYDATA:log_msg}\""
               },
               "named_captures_only": {
                 "@type": "boolean",


### PR DESCRIPTION
## What do these changes do
Update graylog traefik extractor GROK pattern to properly parse log_msg, log_timestamp and log_level

## Related issues
https://github.com/ITISFoundation/osparc-ops-environments/issues/293

## How to test
1. Run `make configure` in `./services/graylog`
2. Check search and ensure that the fields are not empty