### PR TITLE
✨ Add deployment labels for clusters_keeper microservices

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,10 +1,10 @@
 # See https://pre-commit.com/hooks.html for more hooks
 exclude: "^.venv$|^.cache$|^.pytest_cache$"
 default_language_version:
-  python: python3.9
+  python: python3.10
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.2.0
+    rev: v4.4.0
     hooks:
       - id: check-added-large-files
         args: ["--maxkb=499"] # ensures docker config compatability for all files
@@ -75,11 +75,9 @@ repos:
     rev: v2.34.0
     hooks:
       - id: pyupgrade
-        args:
-          - "--py39-plus"
         name: upgrade code
   - repo: https://github.com/hadialqattan/pycln
-    rev: v1.2.5
+    rev: v2.2.2
     hooks:
       - id: pycln
         args: [--all, --expand-stars]
@@ -91,7 +89,7 @@ repos:
         args: ["--profile", "black"]
         name: sort imports
   - repo: https://github.com/pre-commit/pygrep-hooks
-    rev: v1.9.0
+    rev: v1.10.0
     hooks:
       - id: python-no-eval
         name: check for the `eval()` built-in python function
@@ -104,7 +102,6 @@ repos:
         (?x)^(
           services/monitoring/prometheus/.*\.rules\.yml
         )$
-
   #- repo: https://github.com/PyCQA/bandit
   #  rev: 1.7.4
   #  hooks:
@@ -116,7 +113,7 @@ repos:
       - id: shellcheck
         name: Shell scripts conform to shellcheck
   - repo: https://github.com/psf/black
-    rev: 22.3.0
+    rev: 23.7.0
     hooks:
       - id: black
         name: black format code

--- a/services/simcore/docker-compose.yml
+++ b/services/simcore/docker-compose.yml
@@ -1,9 +1,44 @@
-# osparc-simcore stack (framework stack)
-# NOTES :
-# LOGSPOUT_MULTILINE is used to tell to Logspout, which is used by GrayLog, to handle multiline support of the logs of the concerned container. Please add with every new osparc-simcore service.
-# See this issue to have more informations : https://github.com/ITISFoundation/osparc-ops/issues/40
 version: "3.8"
 services:
+  clusters-keeper:
+    hostname: "{{.Node.Hostname}}-{{.Service.Name}}"
+    environment:
+      - LOG_LEVEL=${LOG_LEVEL:-WARNING}
+      - LOG_FORMAT_LOCAL_DEV_ENABLED=${LOG_FORMAT_LOCAL_DEV_ENABLED}
+      - CLUSTERS_KEEPER_LOGLEVEL=${LOG_LEVEL:-INFO}
+      - REDIS_HOST=${REDIS_HOST}
+      - REDIS_PORT=${REDIS_PORT}
+      - RABBIT_HOST=${RABBIT_HOST}
+      - RABBIT_PASSWORD=${RABBIT_PASSWORD}
+      - RABBIT_PORT=${RABBIT_PORT}
+      - RABBIT_SECURE=${RABBIT_SECURE}
+      - RABBIT_USER=${RABBIT_USER}
+    deploy:
+      labels: []
+      update_config:
+        parallelism: 2
+        order: start-first
+        failure_action: rollback
+        delay: 10s
+      rollback_config:
+        parallelism: 0
+        order: stop-first
+      restart_policy:
+        condition: any
+        delay: 5s
+        max_attempts: 3
+        window: 120s
+      resources:
+        limits:
+          memory: 200M # Determined from prometheus cadvisor actual usage on master, which was <100M
+          cpus: '0.5' # For now: same as autoscaling service
+        reservations:
+          memory: 200M # Determined from prometheus cadvisor actual usage on master, which was <100M
+          cpus: '0.5' # For now: same as autoscaling service
+      placement:
+        constraints:
+          - node.labels.simcore==true
+
   autoscaling:
     environment:
       - EC2_ACCESS_KEY_ID=${AUTOSCALING_EC2_ACCESS_KEY_ID} # defines the access key to EC2

--- a/services/simcore/docker-compose.yml
+++ b/services/simcore/docker-compose.yml
@@ -1,7 +1,6 @@
 version: "3.8"
 services:
   clusters-keeper:
-    hostname: "{{.Node.Hostname}}-{{.Service.Name}}"
     environment:
       - LOG_LEVEL=${LOG_LEVEL:-WARNING}
       - LOG_FORMAT_LOCAL_DEV_ENABLED=${LOG_FORMAT_LOCAL_DEV_ENABLED}


### PR DESCRIPTION
- Adds restart_config and resource limits for simcore `clusters_keeper` microservice (see https://github.com/ITISFoundation/osparc-simcore/pull/4591  )

## Bonus:
- Update pre-commit hooks
- Update pre-commit hooks' used python version to 3.10
- Removes deprecated file comment about logspout (which we dont use anymore)