### PR TITLE
Add docker resource limits to 20% services

### DIFF
--- a/services/admin-panels/docker-compose.yml.j2
+++ b/services/admin-panels/docker-compose.yml.j2
@@ -98,10 +98,10 @@ services:
       resources:
         limits:
           memory: "2G"
-          cpus: "0.1"
+          cpus: "1"
         reservations:
           memory: "2G"
-          cpus: "0.1"
+          cpus: "1"
 
 networks:
   public:

--- a/services/admin-panels/docker-compose.yml.j2
+++ b/services/admin-panels/docker-compose.yml.j2
@@ -97,7 +97,11 @@ services:
           - node.role == manager
       resources:
         limits:
-          memory: 2048M
+          memory: "2G"
+          cpus: "0.1"
+        reservations:
+          memory: "2G"
+          cpus: "0.1"
 
 networks:
   public:

--- a/services/adminer/docker-compose.yml
+++ b/services/adminer/docker-compose.yml
@@ -25,8 +25,11 @@ services:
       resources:
         limits:
           memory: 128M
+          cpus: "0.01"
         reservations:
           memory: 64M
+          cpus: "0.01"
+
 
 networks:
   public:

--- a/services/adminer/docker-compose.yml
+++ b/services/adminer/docker-compose.yml
@@ -25,10 +25,10 @@ services:
       resources:
         limits:
           memory: 128M
-          cpus: "0.01"
+          cpus: "0.5"
         reservations:
           memory: 64M
-          cpus: "0.01"
+          cpus: "0.5"
 
 
 networks:

--- a/services/deployment-agent/docker-compose.yml.j2
+++ b/services/deployment-agent/docker-compose.yml.j2
@@ -22,6 +22,13 @@ services:
       replicas: 1
       placement:
         constraints: [node.role == manager]
+      resources:
+        limits:
+          memory: "400M"
+          cpus: "0.1"
+        reservations:
+          memory: "400M"
+          cpus: "0.1"
 networks:
   portainer_agent_network:
     external: true

--- a/services/deployment-agent/docker-compose.yml.j2
+++ b/services/deployment-agent/docker-compose.yml.j2
@@ -25,10 +25,10 @@ services:
       resources:
         limits:
           memory: "400M"
-          cpus: "0.1"
+          cpus: "1"
         reservations:
           memory: "400M"
-          cpus: "0.1"
+          cpus: "1"
 networks:
   portainer_agent_network:
     external: true

--- a/services/filestash/docker-compose.yml
+++ b/services/filestash/docker-compose.yml
@@ -21,7 +21,11 @@ services:
         - traefik.http.routers.filestash.middlewares=ops_whitelist_ips@docker
       resources:
         limits:
-          memory: 512M
+          memory: 120M
+          cpus: "0.01"
+        reservations:
+          memory: 120M
+          cpus: "0.01"
   onlyoffice:
     image: onlyoffice/documentserver:7.4.0
     networks:

--- a/services/filestash/docker-compose.yml
+++ b/services/filestash/docker-compose.yml
@@ -22,10 +22,10 @@ services:
       resources:
         limits:
           memory: 120M
-          cpus: "0.01"
+          cpus: "1"
         reservations:
           memory: 120M
-          cpus: "0.01"
+          cpus: "1"
   onlyoffice:
     image: onlyoffice/documentserver:7.4.0
     networks:

--- a/services/graylog/docker-compose.yml
+++ b/services/graylog/docker-compose.yml
@@ -11,6 +11,13 @@ services:
       replicas: 1
       restart_policy:
         condition: on-failure
+      resources:
+        limits:
+          memory: 1.2G
+          cpus: "0.1"
+        reservations:
+          memory: 1.2G
+          cpus: "0.1"
     networks:
       default:
         aliases:
@@ -35,6 +42,10 @@ services:
       resources:
         limits:
           memory: 1G
+          cpus: "1"
+        reservations:
+          memory: 1G
+          cpus: "1"
   # Graylog: https://hub.docker.com/r/graylog/graylog/
   graylog:
     image: graylog/graylog:5.1.4
@@ -68,11 +79,11 @@ services:
         condition: on-failure
       resources:
         limits:
-          cpus: "8.00"
-          memory: 8G
+          cpus: "2.00"
+          memory: 5G
         reservations:
-          cpus: "4.00"
-          memory: 4G
+          cpus: "2.00"
+          memory: 5G
 
       labels:
         - traefik.enable=true

--- a/services/graylog/docker-compose.yml
+++ b/services/graylog/docker-compose.yml
@@ -14,10 +14,10 @@ services:
       resources:
         limits:
           memory: 1.2G
-          cpus: "0.1"
+          cpus: "1"
         reservations:
           memory: 1.2G
-          cpus: "0.1"
+          cpus: "1"
     networks:
       default:
         aliases:

--- a/services/jaeger/docker-compose.yml
+++ b/services/jaeger/docker-compose.yml
@@ -24,7 +24,11 @@ services:
         - prometheus-port=14269
       resources:
         limits:
-          memory: 2048M
+          memory: 200M
+          cpus: "1"
+        reservations:
+          memory: 200M
+          cpus: "1"
 
 networks:
   public:

--- a/services/monitoring/prometheus/README.md
+++ b/services/monitoring/prometheus/README.md
@@ -13,3 +13,20 @@ Fill in past data for new rules (make sure to backup data before)
 
 This is a useful tool to check prometheus service discovery and relabeling rules:
 https://relabeler.promlabs.com/
+
+###### How to evaluate container CPU usage
+
+```
+sum(rate(container_cpu_usage_seconds_total{container_label_com_docker_swarm_service_name="<service_name>"}[1m])) by (name)
+```
+* rate - [calculate the per-second average rate of how a value is increasing over a period of time](https://www.metricfire.com/blog/understanding-the-prometheus-rate-function/)
+* metric `container_cpu_usage_seconds_total` is ever increasing line as name would suggest. With `rate` function we are able to detect (in milliseconds) the CPU usage per second by a container
+  * `rate(container_cpu_usage_seconds_total[<time frame>])` metric is finally a necessary proporation. I don't fully understand why but I found a few [proofs](https://stackoverflow.com/questions/34923788/prometheus-convert-cpu-user-seconds-to-cpu-usage) on the internet
+  * this is the [best article](https://stackoverflow.com/questions/34923788/prometheus-convert-cpu-user-seconds-to-cpu-usage) I found that explains how to convert this metric to CPU Usage. It is also very helpful to understand the whole query in general
+* without sum we will get the usage per every available CPU, e.g. 1ms of cpu1, 2ms of cpu2, and so on, i.e. we have different records for the same container with the only difference in the cpu used. By summing them up, we get total CPU usage across all the CPUs
+* `by name` is a grouping by container name. It plays nicely since it automatically summs the usage per every CPU core and output the total CPU usage per container
+
+###### How to evaluate container memory
+```
+container_memory_usage_bytes{name="<container_name>"}
+```

--- a/services/monitoring/prometheus/README.md
+++ b/services/monitoring/prometheus/README.md
@@ -21,7 +21,7 @@ sum(rate(container_cpu_usage_seconds_total{container_label_com_docker_swarm_serv
 ```
 * rate - [calculate the per-second average rate of how a value is increasing over a period of time](https://www.metricfire.com/blog/understanding-the-prometheus-rate-function/)
 * metric `container_cpu_usage_seconds_total` is ever increasing line as name would suggest. With `rate` function we are able to detect (in milliseconds) the CPU usage per second by a container
-  * `rate(container_cpu_usage_seconds_total[<time frame>])` metric is finally a necessary proporation. I don't fully understand why but I found a few [proofs](https://stackoverflow.com/questions/34923788/prometheus-convert-cpu-user-seconds-to-cpu-usage) on the internet
+  * `rate(container_cpu_usage_seconds_total[<time frame>])` metric finally presents CPU Usage. I don't fully understand why it does but I found a few [proofs](https://stackoverflow.com/questions/34923788/prometheus-convert-cpu-user-seconds-to-cpu-usage) on the internet
   * this is the [best article](https://stackoverflow.com/questions/34923788/prometheus-convert-cpu-user-seconds-to-cpu-usage) I found that explains how to convert this metric to CPU Usage. It is also very helpful to understand the whole query in general
 * without sum we will get the usage per every available CPU, e.g. 1ms of cpu1, 2ms of cpu2, and so on, i.e. we have different records for the same container with the only difference in the cpu used. By summing them up, we get total CPU usage across all the CPUs
 * `by name` is a grouping by container name. It plays nicely since it automatically summs the usage per every CPU core and output the total CPU usage per container

--- a/services/pg-backup/docker-compose.yml.j2
+++ b/services/pg-backup/docker-compose.yml.j2
@@ -20,6 +20,13 @@ services:
       placement:
         constraints:
           - node.labels.pgbackup==true
+      resources:
+        limits:
+          memory: 6G
+          cpus: "0.01"
+        reservations:
+          memory: 6G
+          cpus: "0.01"
 networks:
   monitored:
     name: ${MONITORED_NETWORK}

--- a/services/pg-backup/docker-compose.yml.j2
+++ b/services/pg-backup/docker-compose.yml.j2
@@ -22,10 +22,10 @@ services:
           - node.labels.pgbackup==true
       resources:
         limits:
-          memory: 100M
+          memory: 512M
           cpus: "0.01"
         reservations:
-          memory: 100M
+          memory: 512M
           cpus: "0.01"
 networks:
   monitored:

--- a/services/pg-backup/docker-compose.yml.j2
+++ b/services/pg-backup/docker-compose.yml.j2
@@ -22,10 +22,10 @@ services:
           - node.labels.pgbackup==true
       resources:
         limits:
-          memory: 6G
+          memory: 100M
           cpus: "0.01"
         reservations:
-          memory: 6G
+          memory: 100M
           cpus: "0.01"
 networks:
   monitored:

--- a/services/pg-backup/docker-compose.yml.j2
+++ b/services/pg-backup/docker-compose.yml.j2
@@ -23,10 +23,10 @@ services:
       resources:
         limits:
           memory: 512M
-          cpus: "0.01"
+          cpus: "0.5"
         reservations:
           memory: 512M
-          cpus: "0.01"
+          cpus: "0.5"
 networks:
   monitored:
     name: ${MONITORED_NETWORK}

--- a/services/redis-commander/docker-compose.yml
+++ b/services/redis-commander/docker-compose.yml
@@ -24,10 +24,10 @@ services:
       resources:
         limits:
           memory: 192M
-          cpus: "0.05"
+          cpus: "0.5"
         reservations:
           memory: 64M
-          cpus: "0.05"
+          cpus: "0.5"
 
 networks:
   public:

--- a/services/redis-commander/docker-compose.yml
+++ b/services/redis-commander/docker-compose.yml
@@ -23,7 +23,7 @@ services:
         - traefik.http.routers.redis.middlewares=ops_auth@docker, ops_gzip@docker, ops_whitelist_ips@docker
       resources:
         limits:
-          memory: 128M  # periodically hits this limit dalco-prod. Should we increase?
+          memory: 192M
           cpus: "0.05"
         reservations:
           memory: 64M

--- a/services/redis-commander/docker-compose.yml
+++ b/services/redis-commander/docker-compose.yml
@@ -23,9 +23,11 @@ services:
         - traefik.http.routers.redis.middlewares=ops_auth@docker, ops_gzip@docker, ops_whitelist_ips@docker
       resources:
         limits:
-          memory: 128M
+          memory: 128M  # periodically hits this limit dalco-prod. Should we increase?
+          cpus: "0.05"
         reservations:
           memory: 64M
+          cpus: "0.05"
 
 networks:
   public:


### PR DESCRIPTION
## Service updated
- Admin panels
- Adminer
- Depl. agent
- Filestash
- Graylog
- Jaeger
- Minio (:exclamation: Skipped since it is not used master / dalco / aws deployments)
- PG_BACKUP (:exclamation: https://github.com/kartoza/docker-pg-backup/issues/85)
- REDIS_COMMANDER