### PR TITLE
Increase resouce-usage-tracker service replicas

### DIFF
--- a/services/simcore/docker-compose.deploy.aws.yml
+++ b/services/simcore/docker-compose.deploy.aws.yml
@@ -9,7 +9,7 @@ services:
           - node.role == worker
   resource-usage-tracker:
     deploy:
-      replicas: 0
+      replicas: 3
   static-webserver:
     hostname: "{{.Node.Hostname}}-{{.Service.Name}}"
   traefik:

--- a/services/simcore/docker-compose.deploy.dalco.yml
+++ b/services/simcore/docker-compose.deploy.dalco.yml
@@ -19,7 +19,7 @@ services:
           - node.role == worker
   resource-usage-tracker:
     deploy:
-      replicas: 0
+      replicas: 3
   traefik:
     command:
       - "--api=true"

--- a/services/simcore/docker-compose.deploy.public.yml
+++ b/services/simcore/docker-compose.deploy.public.yml
@@ -14,7 +14,7 @@ services:
       replicas: 0
   resource-usage-tracker:
     deploy:
-      replicas: 0
+      replicas: 3
   static-webserver:
     hostname: "{{.Node.Hostname}}-{{.Service.Name}}"
   traefik:


### PR DESCRIPTION
Make it 3 on `aws`, `dalco` and `tip` deployments