### PR TITLE
Scale to 0 deployment agent

### DIFF
--- a/services/deployment-agent/docker-compose.yml.j2
+++ b/services/deployment-agent/docker-compose.yml.j2
@@ -19,7 +19,7 @@ services:
       - .env
     deploy:
       mode: replicated
-      replicas: 1
+      replicas: 0
       placement:
         constraints: [node.role == manager]
       resources:


### PR DESCRIPTION
A step forward towards GitLab CI/CD deployes. In case we need deployment_agent, we can still scale it up.