### PR TITLE
Disable payments service on aws & dalco

### DIFF
--- a/services/simcore/docker-compose.deploy.aws.yml
+++ b/services/simcore/docker-compose.deploy.aws.yml
@@ -51,3 +51,7 @@ services:
       resources:
         limits:
           memory: 2048M
+
+  payments:
+    deploy:
+      replicas: 0

--- a/services/simcore/docker-compose.deploy.dalco.yml
+++ b/services/simcore/docker-compose.deploy.dalco.yml
@@ -68,3 +68,6 @@ services:
   clusters-keeper:
     deploy:
       replicas: 0
+  payments:
+    deploy:
+      replicas: 0

--- a/services/simcore/docker-compose.deploy.master.yml
+++ b/services/simcore/docker-compose.deploy.master.yml
@@ -63,3 +63,6 @@ services:
   clusters-keeper:
     deploy:
       replicas: 0
+  payments:  # test prior to a big bang release Sept 2023. Can be deleted after (YH, 09 2023)
+    deploy:
+      replicas: 1

--- a/services/simcore/docker-compose.deploy.public.yml
+++ b/services/simcore/docker-compose.deploy.public.yml
@@ -23,3 +23,6 @@ services:
         - prometheus-job=traefik_simcore_production
   wb-garbage-collector:
     hostname: "{{.Service.Name}}"
+  payments:
+    deploy:
+      replicas: 0


### PR DESCRIPTION
Payments service is not yet ready that is why for safety we disable it on aws, dalco and tip deployments. Thus, it will be only running on master as of now.