### PR TITLE
Remove letsencrypt dns challenge propagation delay

### DIFF
--- a/services/traefik/docker-compose.aws.yml
+++ b/services/traefik/docker-compose.aws.yml
@@ -24,7 +24,7 @@ services:
       - "--providers.docker.constraints=!LabelRegex(`io.simcore.zone`, `.+`)"
       - "--entryPoints.https.forwardedHeaders.insecure"
       - "--certificatesresolvers.myresolver.acme.dnschallenge.provider=route53"
-      - "--certificatesresolvers.myresolver.acme.dnschallenge.delaybeforecheck=120"
+      # - "--certificatesresolvers.myresolver.acme.dnschallenge.delaybeforecheck=120"
       - "--certificatesresolvers.myresolver.acme.email=${OSPARC_DEVOPS_MAIL_ADRESS}"
       - "--certificatesresolvers.myresolver.acme.storage=/letsencrypt/acme.json"
     #  - "--certificatesresolvers.lehttpchallenge.acme.httpchallenge=true"

--- a/services/traefik/docker-compose.aws.yml
+++ b/services/traefik/docker-compose.aws.yml
@@ -24,7 +24,6 @@ services:
       - "--providers.docker.constraints=!LabelRegex(`io.simcore.zone`, `.+`)"
       - "--entryPoints.https.forwardedHeaders.insecure"
       - "--certificatesresolvers.myresolver.acme.dnschallenge.provider=route53"
-      # - "--certificatesresolvers.myresolver.acme.dnschallenge.delaybeforecheck=120"
       - "--certificatesresolvers.myresolver.acme.email=${OSPARC_DEVOPS_MAIL_ADRESS}"
       - "--certificatesresolvers.myresolver.acme.storage=/letsencrypt/acme.json"
     #  - "--certificatesresolvers.lehttpchallenge.acme.httpchallenge=true"

--- a/services/traefik/docker-compose.dalco.yml
+++ b/services/traefik/docker-compose.dalco.yml
@@ -26,7 +26,6 @@ services:
       - "--providers.docker.constraints=!LabelRegex(`io.simcore.zone`, `.+`)"
       - "--entryPoints.https.forwardedHeaders.insecure"
       - "--certificatesresolvers.myresolver.acme.dnschallenge.provider=rfc2136"
-      # - "--certificatesresolvers.myresolver.acme.dnschallenge.delaybeforecheck=120"
       - "--certificatesresolvers.myresolver.acme.email=${OSPARC_DEVOPS_MAIL_ADRESS}"
       - "--certificatesresolvers.myresolver.acme.storage=/letsencrypt/acme.json"
       # For debug purpose, to avoid being ban by let's encrypt servers

--- a/services/traefik/docker-compose.dalco.yml
+++ b/services/traefik/docker-compose.dalco.yml
@@ -26,7 +26,7 @@ services:
       - "--providers.docker.constraints=!LabelRegex(`io.simcore.zone`, `.+`)"
       - "--entryPoints.https.forwardedHeaders.insecure"
       - "--certificatesresolvers.myresolver.acme.dnschallenge.provider=rfc2136"
-      - "--certificatesresolvers.myresolver.acme.dnschallenge.delaybeforecheck=120"
+      # - "--certificatesresolvers.myresolver.acme.dnschallenge.delaybeforecheck=120"
       - "--certificatesresolvers.myresolver.acme.email=${OSPARC_DEVOPS_MAIL_ADRESS}"
       - "--certificatesresolvers.myresolver.acme.storage=/letsencrypt/acme.json"
       # For debug purpose, to avoid being ban by let's encrypt servers

--- a/services/traefik/docker-compose.master.yml
+++ b/services/traefik/docker-compose.master.yml
@@ -25,7 +25,7 @@ services:
       - "--providers.docker.constraints=!LabelRegex(`io.simcore.zone`, `.+`)"
       - "--entryPoints.https.forwardedHeaders.insecure"
       - "--certificatesresolvers.myresolver.acme.dnschallenge.provider=rfc2136"
-      - "--certificatesresolvers.myresolver.acme.dnschallenge.delaybeforecheck=120"
+      # - "--certificatesresolvers.myresolver.acme.dnschallenge.delaybeforecheck=120"
       - "--certificatesresolvers.myresolver.acme.email=${OSPARC_DEVOPS_MAIL_ADRESS}"
       - "--certificatesresolvers.myresolver.acme.storage=/letsencrypt/acme.json"
       # For debug purpose, to avoid being ban by let's encrypt servers

--- a/services/traefik/docker-compose.master.yml
+++ b/services/traefik/docker-compose.master.yml
@@ -25,7 +25,6 @@ services:
       - "--providers.docker.constraints=!LabelRegex(`io.simcore.zone`, `.+`)"
       - "--entryPoints.https.forwardedHeaders.insecure"
       - "--certificatesresolvers.myresolver.acme.dnschallenge.provider=rfc2136"
-      # - "--certificatesresolvers.myresolver.acme.dnschallenge.delaybeforecheck=120"
       - "--certificatesresolvers.myresolver.acme.email=${OSPARC_DEVOPS_MAIL_ADRESS}"
       - "--certificatesresolvers.myresolver.acme.storage=/letsencrypt/acme.json"
       # For debug purpose, to avoid being ban by let's encrypt servers

--- a/services/traefik/docker-compose.public.yml
+++ b/services/traefik/docker-compose.public.yml
@@ -27,7 +27,7 @@ services:
       - "--entryPoints.https.forwardedHeaders.insecure"
       - "--certificatesresolvers.myresolver.acme.dnschallenge.provider=rfc2136"
       - "--certificatesresolvers.myresolver.acme.email=${OSPARC_DEVOPS_MAIL_ADRESS}"
-      - "--certificatesresolvers.myresolver.acme.dnschallenge.delaybeforecheck=120"
+      # - "--certificatesresolvers.myresolver.acme.dnschallenge.delaybeforecheck=120"
       - "--certificatesresolvers.myresolver.acme.storage=/letsencrypt/acme.json"
       # For debug purpose, to avoid being ban by let's encrypt servers
       #- "--certificatesresolvers.myresolver.acme.caserver=https://acme-staging-v02.api.letsencrypt.org/directory"

--- a/services/traefik/docker-compose.public.yml
+++ b/services/traefik/docker-compose.public.yml
@@ -30,7 +30,7 @@ services:
       - "--certificatesresolvers.myresolver.acme.dnschallenge.delaybeforecheck=120"
       - "--certificatesresolvers.myresolver.acme.storage=/letsencrypt/acme.json"
       # For debug purpose, to avoid being ban by let's encrypt servers
-      #- ""
+      #- "--certificatesresolvers.myresolver.acme.caserver=https://acme-staging-v02.api.letsencrypt.org/directory"
       - "--certificatesresolvers.myresolver.acme.dnschallenge.resolvers=${RFC2136_NAMESERVER}"
     volumes:
       - "letsencrypt_certs:/letsencrypt"

--- a/services/traefik/docker-compose.public.yml
+++ b/services/traefik/docker-compose.public.yml
@@ -27,7 +27,6 @@ services:
       - "--entryPoints.https.forwardedHeaders.insecure"
       - "--certificatesresolvers.myresolver.acme.dnschallenge.provider=rfc2136"
       - "--certificatesresolvers.myresolver.acme.email=${OSPARC_DEVOPS_MAIL_ADRESS}"
-      # - "--certificatesresolvers.myresolver.acme.dnschallenge.delaybeforecheck=120"
       - "--certificatesresolvers.myresolver.acme.storage=/letsencrypt/acme.json"
       # For debug purpose, to avoid being ban by let's encrypt servers
       #- "--certificatesresolvers.myresolver.acme.caserver=https://acme-staging-v02.api.letsencrypt.org/directory"


### PR DESCRIPTION
This removes the hardcoded DNS challenge propagation delay which I find unnecessary. It doesn't solve the certificate issue we have.