### PR TITLE
Add: validate simcore stack yml bash script - to be used in CI/CD

### DIFF
--- a/scripts/deployments/validate_simcore_stack_yml.bash
+++ b/scripts/deployments/validate_simcore_stack_yml.bash
@@ -1,8 +1,13 @@
 #!/bin/bash
 set -o nounset
 set -o pipefail
+#
+# This bash script expects the following environment variables to be set:
+# - PREFIX_STACK_NAME: prefix of the stack name
+#
 export COMPOSE_FILE=simcore_stack.yml
 export SETTINGS_BINARY_PATH=/home/scu/.venv/bin
+#
 export SERVICES_PREFIX=${PREFIX_STACK_NAME}
 exit_code=0
 # Download version-pinned yq binary
@@ -11,7 +16,9 @@ mv yq_linux_amd64 yq
 chmod +x yq
 _yq=$(realpath ./yq)
 export _yq
+#
 # start
+#
 for service in $($_yq e '.services | keys | .[]' ${COMPOSE_FILE})
 do
     export TARGETNAME=${service#"${SERVICES_PREFIX}"_}

--- a/scripts/deployments/validate_simcore_stack_yml.bash
+++ b/scripts/deployments/validate_simcore_stack_yml.bash
@@ -1,7 +1,6 @@
 #!/bin/bash
 set -o nounset
 set -o pipefail
-set -x
 export COMPOSE_FILE=simcore_stack.yml
 export SETTINGS_BINARY_PATH=/home/scu/.venv/bin
 export SERVICES_PREFIX=${PREFIX_STACK_NAME}
@@ -11,8 +10,9 @@ python -c "import urllib.request,os,sys,urllib; f = open(os.path.basename(sys.ar
 mv yq_linux_amd64 yq
 chmod +x yq
 _yq=$(realpath ./yq)
+export _yq
 # start
-for service in $(_yq e '.services | keys | .[]' ${COMPOSE_FILE})
+for service in $($_yq e '.services | keys | .[]' ${COMPOSE_FILE})
 do
     export TARGETNAME=${service#"${SERVICES_PREFIX}"_}
     #  continue if the service == director since it doesnt have settings

--- a/scripts/deployments/validate_simcore_stack_yml.bash
+++ b/scripts/deployments/validate_simcore_stack_yml.bash
@@ -1,0 +1,55 @@
+#!/bin/bash
+set -o nounset
+set -o pipefail
+set -x
+export COMPOSE_FILE=simcore_stack.yml
+export SETTINGS_BINARY_PATH=/home/scu/.venv/bin
+for service in $(yq e '.services | keys | .[]' ${COMPOSE_FILE})
+do
+
+    export TARGETNAME=${service#master_}
+    #  continue if the service == director since it doesnt have settings
+    if [ "${TARGETNAME}" == "director" ]; then
+        continue
+    fi
+    if [ "${TARGETNAME}" == "migration" ]; then
+        continue
+    fi
+    if [ "${TARGETNAME}" == "postgres" ]; then
+        continue
+    fi
+    if [ "${TARGETNAME}" == "rabbit" ]; then
+        continue
+    fi
+    if [ "${TARGETNAME}" == "redis" ]; then
+        continue
+    fi
+    if [ "${TARGETNAME}" == "traefik" ]; then
+        continue
+    fi
+    if [ "${TARGETNAME}" == "traefik_api" ]; then
+        continue
+    fi
+    if [ "${TARGETNAME}" == "whoami" ]; then
+        continue
+    fi
+    export TARGETFILE="simcore-service-${TARGETNAME}"
+    echo TARGETFILE="${TARGETFILE}"
+    echo "Assuming targetfile in ${SETTINGS_BINARY_PATH}/${TARGETFILE}"
+    echo "Checking ${SETTINGS_BINARY_PATH}/${TARGETFILE}"
+    if docker compose --file ${COMPOSE_FILE} run --rm "${service}" test -f "${SETTINGS_BINARY_PATH}"/"${TARGETFILE}" > /dev/null 2>&1; then
+        echo "FOUND_EXECUTABLE=${SETTINGS_BINARY_PATH}/$TARGETFILE"
+        export FOUND_EXECUTABLE="${SETTINGS_BINARY_PATH}/$TARGETFILE"
+        if docker compose --file ${COMPOSE_FILE} run --entrypoint "${FOUND_EXECUTABLE}" --rm "${service}" settings --as-json > /dev/null 2>&1; then
+            echo "SUCCESS: Validation of environment variables for ${service}"
+        else
+            echo "ERROR: Validation of environment variables for ${service} failed"
+            docker compose --file ${COMPOSE_FILE} run --entrypoint "${FOUND_EXECUTABLE}" --rm "${service}" settings --as-json
+        fi
+    else
+        echo "WARN: Settings executable not found for ${service}"
+    fi
+
+
+    echo "--------------------------"
+done

--- a/scripts/deployments/validate_simcore_stack_yml.bash
+++ b/scripts/deployments/validate_simcore_stack_yml.bash
@@ -4,10 +4,11 @@ set -o pipefail
 set -x
 export COMPOSE_FILE=simcore_stack.yml
 export SETTINGS_BINARY_PATH=/home/scu/.venv/bin
+export SERVICES_PREFIX=${PREFIX_STACK_NAME}
+exit_code=0
 for service in $(yq e '.services | keys | .[]' ${COMPOSE_FILE})
 do
-
-    export TARGETNAME=${service#master_}
+    export TARGETNAME=${service#"${SERVICES_PREFIX}"_}
     #  continue if the service == director since it doesnt have settings
     if [ "${TARGETNAME}" == "director" ]; then
         continue
@@ -45,6 +46,7 @@ do
         else
             echo "ERROR: Validation of environment variables for ${service} failed"
             docker compose --file ${COMPOSE_FILE} run --entrypoint "${FOUND_EXECUTABLE}" --rm "${service}" settings --as-json
+            exit_code=1
         fi
     else
         echo "WARN: Settings executable not found for ${service}"
@@ -53,3 +55,4 @@ do
 
     echo "--------------------------"
 done
+exit $exit_code

--- a/scripts/deployments/validate_simcore_stack_yml.bash
+++ b/scripts/deployments/validate_simcore_stack_yml.bash
@@ -6,7 +6,13 @@ export COMPOSE_FILE=simcore_stack.yml
 export SETTINGS_BINARY_PATH=/home/scu/.venv/bin
 export SERVICES_PREFIX=${PREFIX_STACK_NAME}
 exit_code=0
-for service in $(yq e '.services | keys | .[]' ${COMPOSE_FILE})
+# Download version-pinned yq binary
+python -c "import urllib.request,os,sys,urllib; f = open(os.path.basename(sys.argv[1]), 'wb'); f.write(urllib.request.urlopen(sys.argv[1]).read()); f.close();" https://github.com/mikefarah/yq/releases/download/v4.29.2/yq_linux_amd64
+mv yq_linux_amd64 yq
+chmod +x yq
+_yq=$(realpath ./yq)
+# start
+for service in $(_yq e '.services | keys | .[]' ${COMPOSE_FILE})
 do
     export TARGETNAME=${service#"${SERVICES_PREFIX}"_}
     #  continue if the service == director since it doesnt have settings

--- a/services/graylog/Makefile
+++ b/services/graylog/Makefile
@@ -87,11 +87,11 @@ ${TEMP_COMPOSE}-aws: docker-compose.yml docker-compose.letsencrypt.dns.yml docke
 .PHONY: configure
 configure: .env ## Test is Graylog is online and configure Graylog inputs
 	@cd scripts;\
-	if [ ! -d "venv" ]; \
+	if [ ! -d ".venv" ]; \
 	then\
-		python3 -m venv venv;\
+		python3 -m venv .venv;\
 	fi;\
-	source venv/bin/activate;\
+	source .venv/bin/activate;\
 	pip install -r requirements.txt > /dev/null 2>&1;\
 	set -o allexport; \
 	source ../$<;\


### PR DESCRIPTION
This uses the simcore-settings library to validate that the pydantic checks of all simcore microservices passes with the env-vars baked into a `simcore_stack.yml` file.

The following docker services that are part of the simcore-stack are bypassed:
- director (no settings library)
- migration (no settings library)
- postgres (3rd party)
- rabbit (3rd party)
- redis (3rd party)
- traefik (3rd party)
- traefik_api (3rd party)
- whoami (3rd party)


This goes with https://git.speag.com/oSparc/osparc-ops-deployment-configuration/-/merge_requests/149

Bonus: Renamed some `venv` folder to `.venv`