### PR TITLE
Add Grafana Dashboards for sim4life.io - initial

### DIFF
--- a/services/monitoring/grafana/provisioning/allDeployments/datasources/2.json
+++ b/services/monitoring/grafana/provisioning/allDeployments/datasources/2.json
@@ -1,0 +1,26 @@
+{
+  "access": "proxy",
+  "basicAuth": true,
+  "basicAuthPassword": "",
+  "basicAuthUser": "",
+  "database": "",
+  "id": 1,
+  "isDefault": true,
+  "jsonData": {
+    "graphiteVersion": "1.1",
+    "tlsAuth": false,
+    "tlsAuthWithCACert": false
+  },
+  "name": "Prometheus-Federation",
+  "orgId": 1,
+  "password": "",
+  "readOnly": false,
+  "secureJsonFields": {},
+  "type": "prometheus",
+  "typeLogoUrl": "",
+  "uid": "AAAks95hb",
+  "url": "http://prometheusfederation:9090",
+  "user": "",
+  "version": 1,
+  "withCredentials": false
+}

--- a/services/monitoring/grafana/provisioning/sim4life.io/dashboards/simcore/sim4life.io-admin-overview.json
+++ b/services/monitoring/grafana/provisioning/sim4life.io/dashboards/simcore/sim4life.io-admin-overview.json
@@ -87,7 +87,7 @@
               "uid": "RmZEr52nz"
             },
             "editorMode": "code",
-            "expr": "avg(osparc_production_members_in_gid_135745)",
+            "expr": "avg(osparc_production_members_in_gid_4)",
             "legendFormat": "__auto",
             "range": true,
             "refId": "A"
@@ -383,7 +383,7 @@
               "uid": "RmZEr52nz"
             },
             "editorMode": "code",
-            "expr": "count(container_memory_usage_bytes{image=~\"^.*[.osparc.io].*/simcore/services/dynamic/s4l-core-lite.*$\",container_label_io_simcore_runtime_simcore_user_agent!=\"puppeteer\"}) OR clamp_max(absent(container_memory_usage_bytes{image=~\"^.*[.osparc.io].*/simcore/services/dynamic/s4l-core-lite.*$\",container_label_io_simcore_runtime_simcore_user_agent!=\"puppeteer\"}),0)",
+            "expr": "count(container_memory_usage_bytes{image=~\"^.*[.sim4life.io].*/simcore/services/dynamic/s4l-core-.*$\",container_label_io_simcore_runtime_simcore_user_agent!=\"puppeteer\"}) OR clamp_max(absent(container_memory_usage_bytes{image=~\"^.*[.sim4life.io].*/simcore/services/dynamic/s4l-core-.*$\",container_label_io_simcore_runtime_simcore_user_agent!=\"puppeteer\"}),0)",
             "legendFormat": "__auto",
             "range": true,
             "refId": "A"
@@ -490,7 +490,7 @@
               "uid": "RmZEr52nz"
             },
             "editorMode": "code",
-            "expr": "sum without (cpu, mode, instance, job) (rate(node_cpu_seconds_total{instance=~\"^ip-.*$\",mode!=\"idle\"}[2m])) / count(count by (cpu) (node_cpu_seconds_total{instance=~\"^ip-.*$\"}))  OR clamp_max(absent(container_memory_usage_bytes{image=~\"^.*[.osparc.io].*/simcore/services/dynamic/s4l-core-lite.*$\"}),0)",
+            "expr": "sum without (cpu, mode, instance, job) (rate(node_cpu_seconds_total{instance=~\"^ip-.*$\",mode!=\"idle\"}[2m])) / count(count by (cpu) (node_cpu_seconds_total{instance=~\"^ip-.*$\"}))  OR clamp_max(absent(container_memory_usage_bytes{image=~\"^.*[.sim4life.io].*/simcore/services/dynamic/s4l-core-.*$\"}),0)",
             "legendFormat": "__auto",
             "range": true,
             "refId": "A"
@@ -583,7 +583,7 @@
               "uid": "RmZEr52nz"
             },
             "editorMode": "code",
-            "expr": "sum(container_memory_usage_bytes{instance=~\"ip-.*\",image=~\"^.*[.osparc.io].*/simcore/services/dynamic/((s4l-.)|(sym-server)).*$\"}) OR clamp_max(absent(container_memory_usage_bytes{image=~\"^.*[.osparc.io].*/simcore/services/dynamic/s4l-core-lite.*$\"}),0)",
+            "expr": "sum(container_memory_usage_bytes{instance=~\"ip-.*\",image=~\"^.*[.sim4life.io].*/simcore/services/dynamic/((s4l-.)|(sym-server)).*$\"}) OR clamp_max(absent(container_memory_usage_bytes{image=~\"^.*[.sim4life.io].*/simcore/services/dynamic/s4l-core-.*$\"}),0)",
             "legendFormat": "__auto",
             "range": true,
             "refId": "A"

--- a/services/monitoring/grafana/provisioning/sim4life.io/dashboards/simcore/sim4life.io-admin-overview.json
+++ b/services/monitoring/grafana/provisioning/sim4life.io/dashboards/simcore/sim4life.io-admin-overview.json
@@ -1,0 +1,648 @@
+{
+  "dashboard": {
+    "annotations": {
+      "list": [
+        {
+          "builtIn": 1,
+          "datasource": {
+            "type": "grafana",
+            "uid": "-- Grafana --"
+          },
+          "enable": true,
+          "hide": true,
+          "iconColor": "rgba(0, 211, 255, 1)",
+          "name": "Annotations & Alerts",
+          "target": {
+            "limit": 100,
+            "matchAny": false,
+            "tags": [],
+            "type": "dashboard"
+          },
+          "type": "dashboard"
+        }
+      ]
+    },
+    "editable": true,
+    "fiscalYearStartMonth": 0,
+    "graphTooltip": 0,
+    "links": [],
+    "liveNow": false,
+    "panels": [
+      {
+        "datasource": {
+          "type": "prometheus",
+          "uid": "RmZEr52nz"
+        },
+        "description": "",
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "continuous-blues"
+            },
+            "decimals": 0,
+            "mappings": [],
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "dark-orange",
+                  "value": null
+                },
+                {
+                  "color": "red",
+                  "value": 80
+                }
+              ]
+            },
+            "unit": "none"
+          },
+          "overrides": []
+        },
+        "gridPos": {
+          "h": 7,
+          "w": 5,
+          "x": 0,
+          "y": 0
+        },
+        "id": 2,
+        "options": {
+          "colorMode": "value",
+          "graphMode": "area",
+          "justifyMode": "auto",
+          "orientation": "auto",
+          "reduceOptions": {
+            "calcs": [
+              "lastNotNull"
+            ],
+            "fields": "",
+            "values": false
+          },
+          "textMode": "auto"
+        },
+        "pluginVersion": "9.4.3",
+        "targets": [
+          {
+            "datasource": {
+              "type": "prometheus",
+              "uid": "RmZEr52nz"
+            },
+            "editorMode": "code",
+            "expr": "avg(osparc_production_members_in_gid_135745)",
+            "legendFormat": "__auto",
+            "range": true,
+            "refId": "A"
+          }
+        ],
+        "title": "Number of registered s4l users",
+        "type": "stat"
+      },
+      {
+        "datasource": {
+          "type": "prometheus",
+          "uid": "RmZEr52nz"
+        },
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "continuous-BlPu"
+            },
+            "decimals": 0,
+            "mappings": [],
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "value": null
+                },
+                {
+                  "color": "red",
+                  "value": 80
+                }
+              ]
+            },
+            "unit": "none"
+          },
+          "overrides": []
+        },
+        "gridPos": {
+          "h": 7,
+          "w": 7,
+          "x": 5,
+          "y": 0
+        },
+        "id": 10,
+        "options": {
+          "colorMode": "value",
+          "graphMode": "area",
+          "justifyMode": "auto",
+          "orientation": "auto",
+          "reduceOptions": {
+            "calcs": [
+              "lastNotNull"
+            ],
+            "fields": "",
+            "values": false
+          },
+          "textMode": "auto"
+        },
+        "pluginVersion": "9.4.3",
+        "targets": [
+          {
+            "datasource": {
+              "type": "prometheus",
+              "uid": "RmZEr52nz"
+            },
+            "editorMode": "code",
+            "expr": "sum(swarm_node_info{instance=~\"^ip-.*$\"})",
+            "legendFormat": "__auto",
+            "range": true,
+            "refId": "A"
+          }
+        ],
+        "title": "Number of total (buffer+active) s4l machines",
+        "type": "stat"
+      },
+      {
+        "datasource": {
+          "type": "prometheus",
+          "uid": "RmZEr52nz"
+        },
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "continuous-BlPu"
+            },
+            "decimals": 0,
+            "mappings": [],
+            "min": 0,
+            "noValue": "0",
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "value": null
+                },
+                {
+                  "color": "red",
+                  "value": 80
+                }
+              ]
+            },
+            "unit": "none"
+          },
+          "overrides": []
+        },
+        "gridPos": {
+          "h": 7,
+          "w": 6,
+          "x": 12,
+          "y": 0
+        },
+        "id": 12,
+        "options": {
+          "colorMode": "value",
+          "graphMode": "area",
+          "justifyMode": "auto",
+          "orientation": "auto",
+          "reduceOptions": {
+            "calcs": [
+              "lastNotNull"
+            ],
+            "fields": "",
+            "values": false
+          },
+          "textMode": "auto"
+        },
+        "pluginVersion": "9.4.3",
+        "targets": [
+          {
+            "datasource": {
+              "type": "prometheus",
+              "uid": "RmZEr52nz"
+            },
+            "editorMode": "code",
+            "expr": "sum(count_values(\"instance\",node_exporter_build_info{instance=~\"^ip-.*$\"}))",
+            "legendFormat": "__auto",
+            "range": true,
+            "refId": "A"
+          }
+        ],
+        "title": "Number of active (\"hot\") s4l machines",
+        "type": "stat"
+      },
+      {
+        "datasource": {
+          "type": "prometheus",
+          "uid": "RmZEr52nz"
+        },
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "continuous-blues"
+            },
+            "decimals": 0,
+            "mappings": [],
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "value": null
+                },
+                {
+                  "color": "red",
+                  "value": 80
+                }
+              ]
+            },
+            "unit": "none"
+          },
+          "overrides": []
+        },
+        "gridPos": {
+          "h": 7,
+          "w": 6,
+          "x": 18,
+          "y": 0
+        },
+        "id": 8,
+        "options": {
+          "colorMode": "value",
+          "graphMode": "area",
+          "justifyMode": "auto",
+          "orientation": "auto",
+          "reduceOptions": {
+            "calcs": [
+              "lastNotNull"
+            ],
+            "fields": "",
+            "values": false
+          },
+          "textMode": "auto"
+        },
+        "pluginVersion": "9.4.3",
+        "targets": [
+          {
+            "datasource": {
+              "type": "prometheus",
+              "uid": "RmZEr52nz"
+            },
+            "editorMode": "code",
+            "expr": "sum(swarm_node_info{instance=~\"^ip-.*$\"}) - ( sum(count_values(\"instance\",node_boot_time_seconds{instance=~\"^ip-.*$\"})) OR clamp_max(absent(node_boot_time_seconds{instance=~\"^ip-.*$\"}),0) )",
+            "legendFormat": "__auto",
+            "range": true,
+            "refId": "A"
+          }
+        ],
+        "title": "Number of s4l buffer machines",
+        "type": "stat"
+      },
+      {
+        "datasource": {
+          "type": "prometheus",
+          "uid": "RmZEr52nz"
+        },
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "continuous-BlPu"
+            },
+            "custom": {
+              "axisCenteredZero": false,
+              "axisColorMode": "text",
+              "axisLabel": "",
+              "axisPlacement": "auto",
+              "barAlignment": 0,
+              "drawStyle": "line",
+              "fillOpacity": 0,
+              "gradientMode": "none",
+              "hideFrom": {
+                "legend": false,
+                "tooltip": false,
+                "viz": false
+              },
+              "lineInterpolation": "smooth",
+              "lineWidth": 2,
+              "pointSize": 5,
+              "scaleDistribution": {
+                "type": "linear"
+              },
+              "showPoints": "auto",
+              "spanNulls": false,
+              "stacking": {
+                "group": "A",
+                "mode": "none"
+              },
+              "thresholdsStyle": {
+                "mode": "off"
+              }
+            },
+            "decimals": 0,
+            "mappings": [],
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "value": null
+                },
+                {
+                  "color": "red",
+                  "value": 80
+                }
+              ]
+            }
+          },
+          "overrides": []
+        },
+        "gridPos": {
+          "h": 7,
+          "w": 24,
+          "x": 0,
+          "y": 7
+        },
+        "id": 4,
+        "options": {
+          "legend": {
+            "calcs": [],
+            "displayMode": "list",
+            "placement": "bottom",
+            "showLegend": false
+          },
+          "tooltip": {
+            "mode": "single",
+            "sort": "none"
+          }
+        },
+        "targets": [
+          {
+            "datasource": {
+              "type": "prometheus",
+              "uid": "RmZEr52nz"
+            },
+            "editorMode": "code",
+            "expr": "count(container_memory_usage_bytes{image=~\"^.*[.osparc.io].*/simcore/services/dynamic/s4l-core-lite.*$\",container_label_io_simcore_runtime_simcore_user_agent!=\"puppeteer\"}) OR clamp_max(absent(container_memory_usage_bytes{image=~\"^.*[.osparc.io].*/simcore/services/dynamic/s4l-core-lite.*$\",container_label_io_simcore_runtime_simcore_user_agent!=\"puppeteer\"}),0)",
+            "legendFormat": "__auto",
+            "range": true,
+            "refId": "A"
+          }
+        ],
+        "title": "Number of s4l-lite studies running (excluding puppeteer from v1.52.0)",
+        "type": "timeseries"
+      },
+      {
+        "collapsed": false,
+        "gridPos": {
+          "h": 1,
+          "w": 24,
+          "x": 0,
+          "y": 14
+        },
+        "id": 18,
+        "panels": [],
+        "title": "Resource Usage",
+        "type": "row"
+      },
+      {
+        "datasource": {
+          "type": "prometheus",
+          "uid": "RmZEr52nz"
+        },
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "continuous-BlPu"
+            },
+            "custom": {
+              "axisCenteredZero": false,
+              "axisColorMode": "text",
+              "axisLabel": "",
+              "axisPlacement": "auto",
+              "barAlignment": 0,
+              "drawStyle": "line",
+              "fillOpacity": 0,
+              "gradientMode": "none",
+              "hideFrom": {
+                "legend": false,
+                "tooltip": false,
+                "viz": false
+              },
+              "lineInterpolation": "smooth",
+              "lineWidth": 2,
+              "pointSize": 7,
+              "scaleDistribution": {
+                "type": "linear"
+              },
+              "showPoints": "auto",
+              "spanNulls": false,
+              "stacking": {
+                "group": "A",
+                "mode": "none"
+              },
+              "thresholdsStyle": {
+                "mode": "off"
+              }
+            },
+            "mappings": [],
+            "noValue": "0",
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "value": null
+                },
+                {
+                  "color": "red",
+                  "value": 80
+                }
+              ]
+            },
+            "unit": "percentunit"
+          },
+          "overrides": []
+        },
+        "gridPos": {
+          "h": 8,
+          "w": 24,
+          "x": 0,
+          "y": 15
+        },
+        "id": 16,
+        "options": {
+          "legend": {
+            "calcs": [],
+            "displayMode": "list",
+            "placement": "bottom",
+            "showLegend": false
+          },
+          "tooltip": {
+            "mode": "single",
+            "sort": "none"
+          }
+        },
+        "targets": [
+          {
+            "datasource": {
+              "type": "prometheus",
+              "uid": "RmZEr52nz"
+            },
+            "editorMode": "code",
+            "expr": "sum without (cpu, mode, instance, job) (rate(node_cpu_seconds_total{instance=~\"^ip-.*$\",mode!=\"idle\"}[2m])) / count(count by (cpu) (node_cpu_seconds_total{instance=~\"^ip-.*$\"}))  OR clamp_max(absent(container_memory_usage_bytes{image=~\"^.*[.osparc.io].*/simcore/services/dynamic/s4l-core-lite.*$\"}),0)",
+            "legendFormat": "__auto",
+            "range": true,
+            "refId": "A"
+          }
+        ],
+        "title": "Total CPU usage of active s4l-lite nodes",
+        "type": "timeseries"
+      },
+      {
+        "datasource": {
+          "type": "prometheus",
+          "uid": "RmZEr52nz"
+        },
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "continuous-BlPu"
+            },
+            "custom": {
+              "axisCenteredZero": false,
+              "axisColorMode": "text",
+              "axisLabel": "",
+              "axisPlacement": "auto",
+              "barAlignment": 0,
+              "drawStyle": "line",
+              "fillOpacity": 0,
+              "gradientMode": "none",
+              "hideFrom": {
+                "legend": false,
+                "tooltip": false,
+                "viz": false
+              },
+              "lineInterpolation": "linear",
+              "lineWidth": 2,
+              "pointSize": 5,
+              "scaleDistribution": {
+                "type": "linear"
+              },
+              "showPoints": "auto",
+              "spanNulls": false,
+              "stacking": {
+                "group": "A",
+                "mode": "none"
+              },
+              "thresholdsStyle": {
+                "mode": "off"
+              }
+            },
+            "mappings": [],
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "value": null
+                },
+                {
+                  "color": "red",
+                  "value": 80
+                }
+              ]
+            },
+            "unit": "bytes"
+          },
+          "overrides": []
+        },
+        "gridPos": {
+          "h": 7,
+          "w": 24,
+          "x": 0,
+          "y": 23
+        },
+        "id": 6,
+        "options": {
+          "legend": {
+            "calcs": [],
+            "displayMode": "list",
+            "placement": "bottom",
+            "showLegend": false
+          },
+          "tooltip": {
+            "mode": "single",
+            "sort": "none"
+          }
+        },
+        "targets": [
+          {
+            "datasource": {
+              "type": "prometheus",
+              "uid": "RmZEr52nz"
+            },
+            "editorMode": "code",
+            "expr": "sum(container_memory_usage_bytes{instance=~\"ip-.*\",image=~\"^.*[.osparc.io].*/simcore/services/dynamic/((s4l-.)|(sym-server)).*$\"}) OR clamp_max(absent(container_memory_usage_bytes{image=~\"^.*[.osparc.io].*/simcore/services/dynamic/s4l-core-lite.*$\"}),0)",
+            "legendFormat": "__auto",
+            "range": true,
+            "refId": "A"
+          }
+        ],
+        "title": "Real-time RAM usage for s4l-lite services",
+        "type": "timeseries"
+      }
+    ],
+    "refresh": "",
+    "revision": 1,
+    "schemaVersion": 38,
+    "style": "dark",
+    "tags": [],
+    "templating": {
+      "list": []
+    },
+    "time": {
+      "from": "now-6h",
+      "to": "now"
+    },
+    "timepicker": {},
+    "timezone": "",
+    "title": "s4l-lite admin overview",
+    "uid": "Jg0sD8-4k",
+    "version": 5,
+    "weekStart": ""
+  },
+  "meta": {
+    "annotationsPermissions": {
+      "dashboard": {
+        "canAdd": true,
+        "canDelete": true,
+        "canEdit": true
+      },
+      "organization": {
+        "canAdd": true,
+        "canDelete": true,
+        "canEdit": true
+      }
+    },
+    "canAdmin": true,
+    "canDelete": true,
+    "canEdit": true,
+    "canSave": true,
+    "canStar": true,
+    "createdBy": "admin",
+    "expires": "0001-01-01T00:00:00Z",
+    "folderTitle": "simcore",
+    "hasAcl": false,
+    "isFolder": false,
+    "provisioned": false,
+    "provisionedExternalId": "",
+    "publicDashboardAccessToken": "",
+    "publicDashboardEnabled": false,
+    "publicDashboardUid": "",
+    "slug": "sim4life.io-admin-overview",
+    "type": "db",
+    "updatedBy": "admin",
+    "url": "/grafana/d/Jg0sD8-4k/s4l-lite-admin-overview"
+  }
+}

--- a/services/monitoring/grafana/provisioning/sim4life.io/dashboards/simcore/sim4life.io-admin-overview.json
+++ b/services/monitoring/grafana/provisioning/sim4life.io/dashboards/simcore/sim4life.io-admin-overview.json
@@ -31,7 +31,7 @@
       {
         "datasource": {
           "type": "prometheus",
-          "uid": "RmZEr52nz"
+          "uid": "AAAks95hb"
         },
         "description": "",
         "fieldConfig": {
@@ -84,7 +84,7 @@
           {
             "datasource": {
               "type": "prometheus",
-              "uid": "RmZEr52nz"
+              "uid": "AAAks95hb"
             },
             "editorMode": "code",
             "expr": "avg(osparc_production_members_in_gid_4)",
@@ -99,7 +99,7 @@
       {
         "datasource": {
           "type": "prometheus",
-          "uid": "RmZEr52nz"
+          "uid": "AAAks95hb"
         },
         "fieldConfig": {
           "defaults": {
@@ -151,7 +151,7 @@
           {
             "datasource": {
               "type": "prometheus",
-              "uid": "RmZEr52nz"
+              "uid": "AAAks95hb"
             },
             "editorMode": "code",
             "expr": "sum(swarm_node_info{instance=~\"^ip-.*$\"})",
@@ -166,7 +166,7 @@
       {
         "datasource": {
           "type": "prometheus",
-          "uid": "RmZEr52nz"
+          "uid": "AAAks95hb"
         },
         "fieldConfig": {
           "defaults": {
@@ -220,7 +220,7 @@
           {
             "datasource": {
               "type": "prometheus",
-              "uid": "RmZEr52nz"
+              "uid": "AAAks95hb"
             },
             "editorMode": "code",
             "expr": "sum(count_values(\"instance\",node_exporter_build_info{instance=~\"^ip-.*$\"}))",
@@ -235,7 +235,7 @@
       {
         "datasource": {
           "type": "prometheus",
-          "uid": "RmZEr52nz"
+          "uid": "AAAks95hb"
         },
         "fieldConfig": {
           "defaults": {
@@ -287,7 +287,7 @@
           {
             "datasource": {
               "type": "prometheus",
-              "uid": "RmZEr52nz"
+              "uid": "AAAks95hb"
             },
             "editorMode": "code",
             "expr": "sum(swarm_node_info{instance=~\"^ip-.*$\"}) - ( sum(count_values(\"instance\",node_boot_time_seconds{instance=~\"^ip-.*$\"})) OR clamp_max(absent(node_boot_time_seconds{instance=~\"^ip-.*$\"}),0) )",
@@ -302,7 +302,7 @@
       {
         "datasource": {
           "type": "prometheus",
-          "uid": "RmZEr52nz"
+          "uid": "AAAks95hb"
         },
         "fieldConfig": {
           "defaults": {
@@ -380,7 +380,7 @@
           {
             "datasource": {
               "type": "prometheus",
-              "uid": "RmZEr52nz"
+              "uid": "AAAks95hb"
             },
             "editorMode": "code",
             "expr": "count(container_memory_usage_bytes{image=~\"^.*[.sim4life.io].*/simcore/services/dynamic/s4l-core-.*$\",container_label_io_simcore_runtime_simcore_user_agent!=\"puppeteer\"}) OR clamp_max(absent(container_memory_usage_bytes{image=~\"^.*[.sim4life.io].*/simcore/services/dynamic/s4l-core-.*$\",container_label_io_simcore_runtime_simcore_user_agent!=\"puppeteer\"}),0)",
@@ -408,7 +408,7 @@
       {
         "datasource": {
           "type": "prometheus",
-          "uid": "RmZEr52nz"
+          "uid": "AAAks95hb"
         },
         "fieldConfig": {
           "defaults": {
@@ -487,7 +487,7 @@
           {
             "datasource": {
               "type": "prometheus",
-              "uid": "RmZEr52nz"
+              "uid": "AAAks95hb"
             },
             "editorMode": "code",
             "expr": "sum without (cpu, mode, instance, job) (rate(node_cpu_seconds_total{instance=~\"^ip-.*$\",mode!=\"idle\"}[2m])) / count(count by (cpu) (node_cpu_seconds_total{instance=~\"^ip-.*$\"}))  OR clamp_max(absent(container_memory_usage_bytes{image=~\"^.*[.sim4life.io].*/simcore/services/dynamic/s4l-core-.*$\"}),0)",
@@ -502,7 +502,7 @@
       {
         "datasource": {
           "type": "prometheus",
-          "uid": "RmZEr52nz"
+          "uid": "AAAks95hb"
         },
         "fieldConfig": {
           "defaults": {
@@ -580,7 +580,7 @@
           {
             "datasource": {
               "type": "prometheus",
-              "uid": "RmZEr52nz"
+              "uid": "AAAks95hb"
             },
             "editorMode": "code",
             "expr": "sum(container_memory_usage_bytes{instance=~\"ip-.*\",image=~\"^.*[.sim4life.io].*/simcore/services/dynamic/((s4l-.)|(sym-server)).*$\"}) OR clamp_max(absent(container_memory_usage_bytes{image=~\"^.*[.sim4life.io].*/simcore/services/dynamic/s4l-core-.*$\"}),0)",

--- a/services/monitoring/grafana/provisioning/sim4life.io/datasources2dashboards.yaml
+++ b/services/monitoring/grafana/provisioning/sim4life.io/datasources2dashboards.yaml
@@ -1,3 +1,6 @@
 defaults:
   - type: "prometheus"
     datasource_name: "Prometheus"
+datasources2dashboards:
+  - dashboard_name: "sim4life.io-admin-overview"
+    datasource_name: "Prometheus-Federation"

--- a/services/monitoring/pgsql_query_exporter_config.yaml.j2
+++ b/services/monitoring/pgsql_query_exporter_config.yaml.j2
@@ -17,7 +17,7 @@ queries:{% for _stack in MONITORED_STACK_NAMES.split(",") if _stack != "" %}{% f
     databases: [postgres_{{_stack}}]
     metrics: [osparc_{{_stack}}_members_in_gid_{{_gid}}]
     sql: |
-      SELECT COUNT(*) as {{_stack}}_members_in_gid_{{_gid}}
+      SELECT COUNT(*) as osparc_{{_stack}}_members_in_gid_{{_gid}}
       FROM users
       JOIN user_to_groups ON users.id = user_to_groups.uid
       JOIN groups ON groups.gid = user_to_groups.gid
@@ -27,12 +27,12 @@ queries:{% for _stack in MONITORED_STACK_NAMES.split(",") if _stack != "" %}{% f
     databases: [postgres_{{_stack}}]
     metrics: [osparc_{{_stack}}_total_number_of_users]
     sql: |
-      SELECT COUNT(*) as {{_stack}}_total_number_of_users
+      SELECT COUNT(*) as osparc_{{_stack}}_total_number_of_users
       FROM users;
   query_{{_stack}}_total_number_of_users_excluding_guests:
     interval: 55
     databases: [postgres_{{_stack}}]
     metrics: [osparc_{{_stack}}_total_number_of_users]
     sql: |
-      SELECT COUNT(*) as {{_stack}}_total_number_of_users
+      SELECT COUNT(*) as osparc_{{_stack}}_total_number_of_users
       FROM users WHERE role <> 'GUEST';{% endfor %}


### PR DESCRIPTION
## What do these changes do?
Add infra for sim4life-io grafana dashboars.

The dashboards use metrics from the federated (long-term-storage) prometheus.

Fixes a bug in `services/monitoring/pgsql_query_exporter_config.yaml.j2`

## Related issue/s

## Related PR/s

## Checklist

- [ ] I tested and it works
