### PR TITLE
Add Changelog when release-tagging

### DIFF
--- a/scripts/pre-commit-hooks/stack-yml-generated-is-valid/launch.bash
+++ b/scripts/pre-commit-hooks/stack-yml-generated-is-valid/launch.bash
@@ -42,6 +42,8 @@ source "$repo_basedir"/scripts/logger.bash
 repo_config=$(cat "$repo_basedir"/.config.location)
 set -o allexport
 # shellcheck disable=SC1090
+export SIMCORE_IMAGE_TAG=master-github-latest
+# shellcheck source=/dev/null.
 source "$repo_config"
 set +o allexport
 #####################


### PR DESCRIPTION
## What do these changes do?
Adds a changelog looking like the one in osparc-simcore to `make release` targets

![image](https://github.com/ITISFoundation/osparc-ops-environments/assets/8209087/67b5a60f-d044-481a-8e69-88d968cb74e8)

**Bonus:** Fixes pre-commit (`stack-yml-generated-is-valid`) due to change in SIMCORE_IMAGE_TAG

## Related issue/s

## Related PR/s

## Checklist

- [x] I tested and it works
