### PR TITLE
✨ Introduce env-vars to control replication of catalog, director-v0, dask-scheduler

### DIFF
--- a/services/monitoring/grafana/provisioning/osparc-testing.click/datasources2dashboards.yaml
+++ b/services/monitoring/grafana/provisioning/osparc-testing.click/datasources2dashboards.yaml
@@ -1,0 +1,3 @@
+defaults:
+  - type: "prometheus"
+    datasource_name: "Prometheus"

--- a/services/simcore/docker-compose.deploy.aws.yml
+++ b/services/simcore/docker-compose.deploy.aws.yml
@@ -18,6 +18,9 @@ services:
   postgres:
     deploy:
       replicas: 0
+  rabbit:
+    deploy:
+      replicas: 0
   traefik:
     command:
       - "--api=true"

--- a/services/simcore/docker-compose.deploy.aws.yml
+++ b/services/simcore/docker-compose.deploy.aws.yml
@@ -18,9 +18,6 @@ services:
   postgres:
     deploy:
       replicas: 0
-  rabbit:
-    deploy:
-      replicas: 0
   traefik:
     command:
       - "--api=true"

--- a/services/simcore/docker-compose.deploy.local.yml
+++ b/services/simcore/docker-compose.deploy.local.yml
@@ -9,7 +9,7 @@ services:
   # need to pass self-signed certificate in /usr/local/share/ca-certificates and call update-ca-certificates
   catalog:
     deploy:
-      replicas: 1
+      replicas: ${SIMCORE_CATALOG_REPLICAS}
   storage:
     secrets:
         - source: storageca.crt
@@ -21,7 +21,7 @@ services:
       - SSL_CERT_FILE=/usr/local/share/ca-certificates/osparc.crt
   director:
     deploy:
-      replicas: 1
+      replicas: ${SIMCORE_DIRECTOR_V0_REPLICAS}
     environment:
       # needed to pass the self-signed certificate to the spawned services
       - DIRECTOR_SELF_SIGNED_SSL_FILENAME=/usr/local/share/ca-certificates/osparc.crt
@@ -65,9 +65,6 @@ services:
     deploy:
       replicas: 1
   rabbit:
-    deploy:
-      replicas: 1
-  dask-scheduler:
     deploy:
       replicas: 1
   datcore-adapter:

--- a/services/simcore/docker-compose.yml
+++ b/services/simcore/docker-compose.yml
@@ -99,7 +99,7 @@ services:
     networks:
       - monitored
     deploy:
-      replicas: 10
+      replicas: ${SIMCORE_CATALOG_REPLICAS}
       update_config:
         parallelism: 2
         order: start-first
@@ -284,7 +284,7 @@ services:
     networks:
       - monitored
     deploy:
-      replicas: 5
+      replicas: ${SIMCORE_DIRECTOR_V0_REPLICAS}
       update_config:
         parallelism: 2
         order: start-first
@@ -347,6 +347,7 @@ services:
     networks:
       - public
     deploy:
+      replicas: ${SIMCORE_DASK_SCHEDULER_REPLICAS}
       update_config:
         parallelism: 2
         order: start-first


### PR DESCRIPTION
## What do these changes do?
- Introduce env-vars to control replication of catalog, director-v0, dask-scheduler

Bonus:
- 🐛 Fixes grafana provisioning on awsmaster

## Related issue/s
https://github.com/ITISFoundation/osparc-ops-environments/issues/461
## Related PR/s
https://git.speag.com/oSparc/osparc-ops-deployment-configuration/-/merge_requests/221
## Checklist

- [x] I tested and it works
