### PR TITLE
bumping GC limit, too low

### DIFF
--- a/services/simcore/docker-compose.yml
+++ b/services/simcore/docker-compose.yml
@@ -305,7 +305,7 @@ services:
           cpus: "0.1"
           memory: "256M"
         limits:
-          cpus: "0.2"
+          cpus: "1.0"
           memory: "512M"
 
   storage:


### PR DESCRIPTION
## What do these changes do?

CPU reservation for the garbage collector is too low. On some deployments it does not even start.
Assigning more CPU, since when the GC needs to collect a lot of orphan services it requires the CPU time.

## Related issue/s

## Related PR/s

## Checklist

- [x] I tested and it works
