### PR TITLE
bumping cpu limit on webserver

### DIFF
--- a/services/simcore/docker-compose.yml
+++ b/services/simcore/docker-compose.yml
@@ -243,7 +243,7 @@ services:
           cpus: "0.1"
           memory: "512M"
         limits:
-          cpus: "1"
+          cpus: "4"
           memory: "2G"
     extra_hosts: []
 


### PR DESCRIPTION
## What do these changes do?

Allow more resources for wbeserver instances so they can better deal with load while sending messages via socket.io

This will mitigate the effects (until we can do better) but not solve the issue fully.

**Note:** Chose `4CPUs` because the webserver when dealing with a lot of incoming messages via socketio it uses up to 250% CPU. I'd like for it to be able to spike without impacting performance, if possible.


## Related issue/s

- https://git.speag.com/oSparc/osparc-infra/-/issues/48#note_184927

## Related PR/s

## Checklist

- [x] I tested and it works
