### PR TITLE
Change deploy policy

### DIFF
--- a/services/simcore/docker-compose.yml
+++ b/services/simcore/docker-compose.yml
@@ -396,7 +396,7 @@ services:
     deploy:
       update_config:
         parallelism: 2
-        order: start-first
+        order: stop-first
         failure_action: continue
         delay: 10s
       restart_policy:


### PR DESCRIPTION
## What do these changes do?

In order to avoid issues with existing services, `director-v2` must first be killed and then started.

## Related issue/s

## Related PR/s

- fixes https://github.com/ITISFoundation/osparc-ops-environments/issues/563
## Checklist

- [ ] I tested and it works
