### PR TITLE
fix sed regex in docker-compose helper bashscript

### DIFF
--- a/scripts/docker-compose-config.bash
+++ b/scripts/docker-compose-config.bash
@@ -72,7 +72,7 @@ compose \
  config \
 | sed '/published:/s/\"//g' \
 | sed '/size:/s/\"//g' \
-| sed '1 { /name:.*/d ; }' \
+| sed '/^name: /d' \
 | sed '1 i version: \"${version}\"' \
 | sed --regexp-extended 's/cpus: ([0-9\\.]+)/cpus: \"\\1\"/'"
 


### PR DESCRIPTION
## What do these changes do?
Change regex.
Prior `sed` regex assumed `name:` came on line one. It can come in any line and needs to be removed.
The updated regex will remove all lines that start with `name:  `, although we expect one at most.
This is needed to deploy traefik to dalco.
## Related issue/s

## Related PR/s

## Checklist

- [x] I tested and it works
