### PR TITLE
Fix validations script

### DIFF
--- a/scripts/deployments/validate_simcore_stack_yml.bash
+++ b/scripts/deployments/validate_simcore_stack_yml.bash
@@ -37,6 +37,9 @@ for service in $($_yq e '.services | keys | .[]' ${COMPOSE_FILE}); do
     if [ "${TARGETNAME}" == "redis" ]; then
         continue
     fi
+    if [ "${TARGETNAME}" == "static-webserver" ]; then
+        continue
+    fi
     if [ "${TARGETNAME}" == "traefik" ]; then
         continue
     fi
@@ -50,7 +53,7 @@ for service in $($_yq e '.services | keys | .[]' ${COMPOSE_FILE}); do
     echo TARGET_BINARY="${TARGET_BINARY}"
     echo "Assuming TARGET_BINARY in ${SETTINGS_BINARY_PATH}/${TARGET_BINARY}"
     # Pull image from registry, just in case
-    docker compose --file ${COMPOSE_FILE} pull "${service}"
+    docker compose --file ${COMPOSE_FILE} pull --policy always "${service}"
     #
     if docker compose --file ${COMPOSE_FILE} run --rm "${service}" test -f "${SETTINGS_BINARY_PATH}"/"${TARGET_BINARY}" >/dev/null 2>&1; then
         echo "FOUND_EXECUTABLE=${SETTINGS_BINARY_PATH}/${TARGET_BINARY}"
@@ -63,7 +66,8 @@ for service in $($_yq e '.services | keys | .[]' ${COMPOSE_FILE}); do
             exit_code=1
         fi
     else
-        echo "WARN: Settings executable not found for ${service}"
+        echo "ERROR: Settings executable not found for ${service}"
+        exit_code=1
     fi
 
     echo "--------------------------"


### PR DESCRIPTION
## What do these changes do?
Fixes simcore microservice settings validation script.
Changes behavior: Fail if settings binary is missing, explicitly whitelist legacy & external docker images that dont have the common settings library from simcore
## Related issue/s

## Related PR/s

## Checklist

- [x] I tested and it works
