### PR TITLE
adding basic authentication to external clusters

### DIFF
--- a/services/monitoring/prometheus/prometheus-aws.yml
+++ b/services/monitoring/prometheus/prometheus-aws.yml
@@ -18,6 +18,9 @@ scrape_configs:
             values: ["computational"]
           - name: "tag:role"
             values: ["manager"]
+    basic_auth:
+      username: ${PRIMARY_EC2_INSTANCES_PROMETHEUS_USERNAME}
+      password: ${PRIMARY_EC2_INSTANCES_PROMETHEUS_PASSWORD}
 
     relabel_configs:
       - source_labels: [__meta_ec2_public_dns_name] # or use __meta_ec2_instance_id, __meta_ec2_private_ip depending on your network setup


### PR DESCRIPTION
## What do these changes do?
connects main prometheus with external clusters using basic authentication
## Related issue/s

## Related PR/s

## Checklist

- [ ] I tested and it works
