### PR TITLE
Revert "Director v2 avoid ops node"

### DIFF
--- a/services/simcore/docker-compose.yml
+++ b/services/simcore/docker-compose.yml
@@ -431,9 +431,7 @@ services:
         limits:
           cpus: "1"
           memory: "1G"
-      placement:
-        constraints:
-          - node.labels.ops != true
+
   dask-sidecar:
     networks:
       - monitored


### PR DESCRIPTION
Reason: there are deployments where there is only one manager and ops node and they are the same machine.

Reverts ITISFoundation/osparc-ops-environments#633