### PR TITLE
⚡️ Reduce number of git-repo interconnections (`3 --> 1`)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -133,8 +133,6 @@ docs/_build
 
 # Simcore: Contains location of repo.config file on the machine and of the whole config directory
 .config.location
-.config.dir
-.shared_config.dir
 
 # Simcore: Files from osparc-simcore
 yq

--- a/scripts/common.Makefile
+++ b/scripts/common.Makefile
@@ -238,44 +238,6 @@ clean-default: .check_clean ## Cleans all outputs
 			 	--label-add minio=true {}' > /dev/null; \
 	fi
 
-.PHONY: .config.dir
-.config.dir:
-	$(eval CONFIG_DIR_LOCATION=$(REPO_BASE_DIR)/.config.dir)
-
-	@if [ ! -f  $(CONFIG_DIR_LOCATION) ]; then \
-		echo "Error: file does not exist $(CONFIG_DIR_LOCATION)" >&2; \
-		exit 1; \
-	fi
-	@LINE_COUNT=$$(wc -l < $(CONFIG_DIR_LOCATION)); \
-	if [ $$LINE_COUNT -ne 1 ]; then \
-		echo "Error: $(CONFIG_DIR_LOCATION) must contain exactly one '\n'" >&2; \
-		exit 1; \
-	fi
-	$(eval CONFIG_DIR=$(shell cat $(CONFIG_DIR_LOCATION)))
-	@if [ ! -d $(CONFIG_DIR) ]; then \
-		echo "Error: directory does not exist: $(CONFIG_DIR)" >&2; \
-		exit 1; \
-	fi
-
-.PHONY: .shared_config.dir
-.shared_config.dir:
-	$(eval SHARED_CONFIG_DIR_LOCATION=$(REPO_BASE_DIR)/.shared_config.dir)
-
-	@if [ ! -f  $(SHARED_CONFIG_DIR_LOCATION) ]; then \
-		echo "Error: file does not exist $(SHARED_CONFIG_DIR_LOCATION)" >&2; \
-		exit 1; \
-	fi
-	@LINE_COUNT=$$(wc -l < $(SHARED_CONFIG_DIR_LOCATION)); \
-	if [ $$LINE_COUNT -ne 1 ]; then \
-		echo "Error: $(SHARED_CONFIG_DIR_LOCATION) must contain exactly one '\n'" >&2; \
-		exit 1; \
-	fi
-	$(eval CONFIG_DIR=$(shell cat $(SHARED_CONFIG_DIR_LOCATION)))
-	@if [ ! -d $(CONFIG_DIR) ]; then \
-		echo "Error: directory does not exist: $(CONFIG_DIR)" >&2; \
-		exit 1; \
-	fi
-
 # Gracefully use defaults and potentially overwrite them, via https://stackoverflow.com/a/49804748
 %:  %-default
 	@ true

--- a/services/monitoring/Makefile
+++ b/services/monitoring/Makefile
@@ -173,23 +173,16 @@ smokeping_prober_config.yaml: smokeping_prober_config.yaml.j2 ${REPO_CONFIG_LOCA
 	$(call jinja, $<, $@);
 
 .PHONY: grafana/assets
-grafana/assets: .config.dir .shared_config.dir
-	$(eval CONFIG_DIR=$(shell cat $(REPO_BASE_DIR)/.config.dir))
-	$(eval SHARED_CONFIG_DIR=$(shell cat $(REPO_BASE_DIR)/.shared_config.dir))
-
-	$(eval GRAFANA_ASSETS_DIR=$(CONFIG_DIR)/assets/grafana)
-	@if [ ! -d $(GRAFANA_ASSETS_DIR) ]; then \
-		echo "Error: folder does not exist $(GRAFANA_ASSETS_DIR)" >&2; \
+grafana/assets: ${REPO_CONFIG_LOCATION}
+	@if [ ! -d "$(shell dirname ${REPO_CONFIG_LOCATION})/assets/grafana" ]; then \
+		echo "Error: folder does not exist $$GRAFANA_ASSETS_DIR" >&2; \
 		exit 1; \
-	fi
-
-	$(eval GRAFANA_COMMON_ASSETS_DIR=$(SHARED_CONFIG_DIR)/assets/grafana)
-	@if [ ! -d $(GRAFANA_COMMON_ASSETS_DIR) ]; then \
-		echo "Error: folder does not exist $(GRAFANA_COMMON_ASSETS_DIR)" >&2; \
+	fi; \
+	if [ ! -d "$(shell dirname ${REPO_CONFIG_LOCATION})/../shared/assets/grafana" ]; then \
+		echo "Error: folder does not exist $$GRAFANA_COMMON_ASSETS_DIR" >&2; \
 		exit 1; \
-	fi
-
-	@rm -rf $(REPO_BASE_DIR)/services/monitoring/grafana/assets || true
-	@mkdir -p $(REPO_BASE_DIR)/services/monitoring/grafana/assets
-	@cp -r $(GRAFANA_ASSETS_DIR)/* $(REPO_BASE_DIR)/services/monitoring/grafana/assets
-	@cp -r $(GRAFANA_COMMON_ASSETS_DIR) $(REPO_BASE_DIR)/services/monitoring/grafana/assets/shared
+	fi; \
+	rm -rf $(REPO_BASE_DIR)/services/monitoring/grafana/assets || true; \
+	mkdir -p $(REPO_BASE_DIR)/services/monitoring/grafana/assets; \
+	cp -r $(shell dirname ${REPO_CONFIG_LOCATION})/assets/grafana/* $(REPO_BASE_DIR)/services/monitoring/grafana/assets; \
+	cp -r $(shell dirname ${REPO_CONFIG_LOCATION})/../shared/assets/grafana $(REPO_BASE_DIR)/services/monitoring/grafana/assets/shared; \


### PR DESCRIPTION
## What do these changes do?
@YuryHrytsuk recently nicely refactored the grafana dashboards (which are per-deployment assets) from this repo into the ops-config repo. This is the correct place for them to be. In the process however, the interconnection between the git-repos was made more complicated, since 2 new "linker" files to specify directories containing grafana dashboards were introduced. This makes setting up the interconnected ops-repos harder for backend developers.

This PR refactors this and again reduced the number of linker files to 1, the known and old ".config.location" file that specifies the location of the `repo.config` file.

This PR then, instead of requiring more paths explicitly, will implicitly derive the location of grafana dashboard containing directories in ops-config *relative to the repo.config filepath*. 

feedback welcome!
## Related issue/s

## Related PR/s

## Checklist

- [x] I tested and it works
