### PR TITLE
Refactor/open postgres on osparc public

### DIFF
--- a/services/simcore/docker-compose.deploy.public.yml
+++ b/services/simcore/docker-compose.deploy.public.yml
@@ -28,7 +28,7 @@ services:
         - traefik.tcp.routers.${SWARM_STACK_NAME}_postgresRoute.service=${SWARM_STACK_NAME}_postgresRoute
         - traefik.tcp.services.${SWARM_STACK_NAME}_postgresRoute.loadbalancer.server.port=5432
         - "traefik.tcp.routers.${SWARM_STACK_NAME}_postgresRoute.rule=ClientIP(`195.176.8.0/24`) || ClientIP(`10.0.0.0/8`) || ClientIP(`172.16.0.0/12`) || ClientIP(`192.168.0.0/16`)"
-  
+
   wb-garbage-collector:
     hostname: "{{.Service.Name}}"
   payments:

--- a/services/simcore/docker-compose.deploy.public.yml
+++ b/services/simcore/docker-compose.deploy.public.yml
@@ -21,6 +21,14 @@ services:
     deploy:
       labels:
         - prometheus-job=traefik_simcore_production
+        # oSparc postgres
+        - traefik.tcp.routers.${SWARM_STACK_NAME}_postgresRoute.entrypoints=postgres
+        - traefik.tcp.routers.${SWARM_STACK_NAME}_postgresRoute.entrypoints=${PREFIX_STACK_NAME}_postgres
+        - traefik.tcp.routers.${SWARM_STACK_NAME}_postgresRoute.tls=false
+        - traefik.tcp.routers.${SWARM_STACK_NAME}_postgresRoute.service=${SWARM_STACK_NAME}_postgresRoute
+        - traefik.tcp.services.${SWARM_STACK_NAME}_postgresRoute.loadbalancer.server.port=5432
+        - "traefik.tcp.routers.${SWARM_STACK_NAME}_postgresRoute.rule=ClientIP(`195.176.8.0/24`) || ClientIP(`10.0.0.0/8`) || ClientIP(`172.16.0.0/12`) || ClientIP(`192.168.0.0/16`)"
+  
   wb-garbage-collector:
     hostname: "{{.Service.Name}}"
   payments:


### PR DESCRIPTION
## What do these changes do?
Connects postgres to the ops-traefik (aka the "outside world") on osparc-public. Needs a release to prod to become effective. There might be further firewalls by O+P in place that needs to be adjusted
## Related issue/s
https://github.com/ITISFoundation/osparc-issues/issues/1309
## Related PR/s

## Checklist

- [ ] I tested and it works
