### PR TITLE
adds new web-api service starting with two replicas

### DIFF
--- a/services/simcore/docker-compose.deploy.master.yml
+++ b/services/simcore/docker-compose.deploy.master.yml
@@ -69,7 +69,11 @@ services:
 
   webserver:
     deploy:
-      replicas: 6
+      replicas: 3
+
+  wb-api-server:
+    deploy:
+      replicas: 3
 
   storage:
     deploy:

--- a/services/simcore/docker-compose.yml
+++ b/services/simcore/docker-compose.yml
@@ -268,6 +268,7 @@ services:
         <<: *webserver_resources
     extra_hosts: []
 
+
   wb-db-event-listener:
     hostname: "{{.Service.Name}}"
     environment:

--- a/services/simcore/docker-compose.yml
+++ b/services/simcore/docker-compose.yml
@@ -255,7 +255,7 @@ services:
           memory: "2G"
     extra_hosts: []
 
-  web-api:
+  wb-api-server:
     deploy:
       update_config:
         parallelism: 2

--- a/services/simcore/docker-compose.yml
+++ b/services/simcore/docker-compose.yml
@@ -255,6 +255,31 @@ services:
           memory: "2G"
     extra_hosts: []
 
+  web-api:
+    deploy:
+      update_config:
+        parallelism: 2
+        order: start-first
+        failure_action: continue
+        delay: 10s
+      restart_policy:
+        condition: any
+        delay: 5s
+        max_attempts: 3
+        window: 120s
+      replicas: 2
+      placement:
+        constraints:
+          - node.labels.simcore==true
+      resources:
+        reservations:
+          cpus: "0.1"
+          memory: "512M"
+        limits:
+          cpus: "4"
+          memory: "2G"
+    extra_hosts: []
+
   wb-db-event-listener:
     hostname: "{{.Service.Name}}"
     environment:

--- a/services/simcore/docker-compose.yml
+++ b/services/simcore/docker-compose.yml
@@ -232,12 +232,12 @@ services:
         - traefik.http.routers.${SWARM_STACK_NAME}_webserver_swagger.priority=2
         - traefik.http.middlewares.${SWARM_STACK_NAME_NO_HYPHEN}_webserver_swagger_auth.basicauth.users=${TRAEFIK_USER}:${TRAEFIK_PASSWORD}
         - traefik.http.routers.${SWARM_STACK_NAME}_webserver_swagger.middlewares=${SWARM_STACK_NAME_NO_HYPHEN}_webserver_swagger_auth, ${SWARM_STACK_NAME_NO_HYPHEN}_sslheader
-      update_config:
+      update_config: &webserver_update_config
         parallelism: 2
         order: start-first
         failure_action: continue
         delay: 10s
-      restart_policy:
+      restart_policy: &webserver_restart_policy
         condition: any
         delay: 5s
         max_attempts: 3
@@ -246,7 +246,7 @@ services:
       placement:
         constraints:
           - node.labels.simcore==true
-      resources:
+      resources: &webserver_resources
         reservations:
           cpus: "0.1"
           memory: "512M"
@@ -258,26 +258,14 @@ services:
   wb-api-server:
     deploy:
       update_config:
-        parallelism: 2
-        order: start-first
-        failure_action: continue
-        delay: 10s
+        <<: *webserver_update_config
       restart_policy:
-        condition: any
-        delay: 5s
-        max_attempts: 3
-        window: 120s
-      replicas: 2
+        <<: *webserver_restart_policy
       placement:
         constraints:
           - node.labels.simcore==true
       resources:
-        reservations:
-          cpus: "0.1"
-          memory: "512M"
-        limits:
-          cpus: "4"
-          memory: "2G"
+        <<: *webserver_resources
     extra_hosts: []
 
   wb-db-event-listener:


### PR DESCRIPTION
## What do these changes do?

- adds deploy configs for `wb-api-server`, a new service is introduced in https://github.com/ITISFoundation/osparc-simcore/pull/5767. 

- NOTE that this configuration needs to be moved to `docker-compose.yml` as soon as  https://github.com/ITISFoundation/osparc-simcore/pull/5767 reaches staging and production

## Related PR/s

- This needs to get into master **after** PR https://github.com/ITISFoundation/osparc-simcore/pull/5767, right?

## Checklist

- [x] I tested and it works
<img width="1262" alt="image" src="https://github.com/ITISFoundation/osparc-ops-environments/assets/32402063/c9510e3b-fd81-4562-9e3a-3153e793ce41">
