### PR TITLE
Fix makefile issues

### DIFF
--- a/scripts/common.Makefile
+++ b/scripts/common.Makefile
@@ -34,12 +34,12 @@ endif
 
 
 # Parse the different FQDNS in the repo.config (REPO_CONFIG_LOCATION) and convert them into traefik typo and add the service rule
-export DEPLOYMENT_FQDNS_CAPTURE_TRAEFIK_RULE_CATCHALL=$(shell set -o allexport; \
+export DEPLOYMENT_FQDNS_CAPTURE_TRAEFIK_RULE_CATCHALL:=$(shell set -o allexport; \
 	source $(REPO_CONFIG_LOCATION); \
 	if [ -z "$${DEPLOYMENT_FQDNS}" ]; then \
 		DEPLOYMENT_FQDNS_CAPTURE_TRAEFIK_RULE_CATCHALL="(Host(\`$$MACHINE_FQDN\`) && PathPrefix(\`/\`)) || (Host(\`invitations.$$MACHINE_FQDN\`))|| (Host(\`storage.$$MACHINE_FQDN\`)) || (HostRegexp(\`services.$$MACHINE_FQDN\`,\`{subhost:[a-zA-Z0-9-]+}.services.$$MACHINE_FQDN\`) && PathPrefix(\`/\`)) || (HostRegexp(\`services.testing.$$MACHINE_FQDN\`,\`{subhost:[a-zA-Z0-9-]+}.services.testing.$$MACHINE_FQDN\`) && PathPrefix(\`/\`))"; \
 	else \
-		IFS=', ' read -r -a hosts <<< "$${DEPLOYMENT_FQDNS}"; \
+		IFS=',' read -r -a hosts <<< "$${DEPLOYMENT_FQDNS}"; \
 		DEPLOYMENT_FQDNS_CAPTURE_TRAEFIK_RULE_CATCHALL="(Host(\`$$MACHINE_FQDN\`) && PathPrefix(\`/\`)) || (Host(\`invitations.$$MACHINE_FQDN\`))|| (Host(\`storage.$$MACHINE_FQDN\`)) || (HostRegexp(\`services.$$MACHINE_FQDN\`,\`{subhost:[a-zA-Z0-9-]+}.services.$$MACHINE_FQDN\`) && PathPrefix(\`/\`)) || (HostRegexp(\`services.testing.$$MACHINE_FQDN\`,\`{subhost:[a-zA-Z0-9-]+}.services.testing.$$MACHINE_FQDN\`) && PathPrefix(\`/\`))"; \
 		for element in "$${hosts[@]}"; \
 		do \
@@ -50,7 +50,7 @@ export DEPLOYMENT_FQDNS_CAPTURE_TRAEFIK_RULE_CATCHALL=$(shell set -o allexport; 
 	echo $$DEPLOYMENT_FQDNS_CAPTURE_TRAEFIK_RULE_CATCHALL; \
 	set +o allexport; )
 
-export DEPLOYMENT_FQDNS_CAPTURE_INVITATIONS=$(shell set -o allexport; \
+export DEPLOYMENT_FQDNS_CAPTURE_INVITATIONS:=$(shell set -o allexport; \
 	source $(REPO_CONFIG_LOCATION); \
 	if [ -z "$${DEPLOYMENT_FQDNS}" ]; then \
 		DEPLOYMENT_FQDNS_CAPTURE_INVITATIONS="(Host(\`invitations.$$MACHINE_FQDN\`))"; \
@@ -66,7 +66,7 @@ export DEPLOYMENT_FQDNS_CAPTURE_INVITATIONS=$(shell set -o allexport; \
 	echo $$DEPLOYMENT_FQDNS_CAPTURE_INVITATIONS; \
 	set +o allexport; )
 
-export DEPLOYMENT_FQDNS_CAPTURE_STORAGE=$(shell set -o allexport; \
+export DEPLOYMENT_FQDNS_CAPTURE_STORAGE:=$(shell set -o allexport; \
 	source $(REPO_CONFIG_LOCATION); \
 	if [ -z "$${DEPLOYMENT_FQDNS}" ]; then \
 		DEPLOYMENT_FQDNS_CAPTURE_STORAGE="(Host(\`storage.$$MACHINE_FQDN\`))"; \
@@ -82,7 +82,7 @@ export DEPLOYMENT_FQDNS_CAPTURE_STORAGE=$(shell set -o allexport; \
 	echo $$DEPLOYMENT_FQDNS_CAPTURE_STORAGE; \
 	set +o allexport; )
 
-export DEPLOYMENT_FQDNS_CAPTURE_TRAEFIK_RULE_MAINTENANCE_PAGE=$(shell set -o allexport; \
+export DEPLOYMENT_FQDNS_CAPTURE_TRAEFIK_RULE_MAINTENANCE_PAGE:=$(shell set -o allexport; \
 	source $(REPO_CONFIG_LOCATION); \
 	if [ -z "$${DEPLOYMENT_FQDNS}" ]; then \
 		DEPLOYMENT_FQDNS_CAPTURE_TRAEFIK_RULE_MAINTENANCE_PAGE="(Host(\`$$MACHINE_FQDN\`) && PathPrefix(\`/\`)) || (HostRegexp(\`services.$$MACHINE_FQDN\`,\`{subhost:[a-zA-Z0-9-]+}.services.$$MACHINE_FQDN\`) && PathPrefix(\`/\`))"; \
@@ -98,7 +98,7 @@ export DEPLOYMENT_FQDNS_CAPTURE_TRAEFIK_RULE_MAINTENANCE_PAGE=$(shell set -o all
 	echo $$DEPLOYMENT_FQDNS_CAPTURE_TRAEFIK_RULE_MAINTENANCE_PAGE; \
 	set +o allexport; )
 
-export DEPLOYMENT_FQDNS_TESTING_CAPTURE_TRAEFIK_RULE=$(shell set -o allexport; \
+export DEPLOYMENT_FQDNS_TESTING_CAPTURE_TRAEFIK_RULE:=$(shell set -o allexport; \
 	source $(REPO_CONFIG_LOCATION); \
 	if [ -z "$${DEPLOYMENT_FQDNS}" ]; then \
 		DEPLOYMENT_FQDNS_TESTING_CAPTURE_TRAEFIK_RULE="(Host(\`testing.$$MACHINE_FQDN\`) && PathPrefix(\`/\`))"; \
@@ -114,7 +114,7 @@ export DEPLOYMENT_FQDNS_TESTING_CAPTURE_TRAEFIK_RULE=$(shell set -o allexport; \
 	echo $$DEPLOYMENT_FQDNS_TESTING_CAPTURE_TRAEFIK_RULE; \
 	set +o allexport; )
 
-export DEPLOYMENT_FQDNS_APPMOTION_CAPTURE_TRAEFIK_RULE=$(shell set -o allexport; \
+export DEPLOYMENT_FQDNS_APPMOTION_CAPTURE_TRAEFIK_RULE:=$(shell set -o allexport; \
 	source $(REPO_CONFIG_LOCATION); \
 	if [ -z "$${DEPLOYMENT_FQDNS}" ]; then \
 		DEPLOYMENT_FQDNS_APPMOTION_CAPTURE_TRAEFIK_RULE="(Host(\`pay.$$MACHINE_FQDN\`) && PathPrefix(\`/\`))"; \
@@ -131,7 +131,7 @@ export DEPLOYMENT_FQDNS_APPMOTION_CAPTURE_TRAEFIK_RULE=$(shell set -o allexport;
 	set +o allexport; )
 
 # Parse the different FQDNS in repo.config and convert them into traefik typo for APIs subdomains
-export DEPLOYMENT_API_DOMAIN_CAPTURE_TRAEFIK_RULE=$(shell set -o allexport; \
+export DEPLOYMENT_API_DOMAIN_CAPTURE_TRAEFIK_RULE:=$(shell set -o allexport; \
 	source $(REPO_CONFIG_LOCATION); \
 	DEPLOYMENT_API_DOMAIN_CAPTURE_TRAEFIK_RULE="Host(\`$$API_DOMAIN\`) && PathPrefix(\`/\`)"; \
 	if [ ! -z "$${DEPLOYMENT_FQDNS}" ]; then \
@@ -146,7 +146,7 @@ export DEPLOYMENT_API_DOMAIN_CAPTURE_TRAEFIK_RULE=$(shell set -o allexport; \
 	set +o allexport; )
 
 # Parse the different FQDNS in repo.config and convert them into traefik typo for APIs subdomains
-export DEPLOYMENT_API_DOMAIN_TESTING_CAPTURE_TRAEFIK_RULE=$(shell set -o allexport; \
+export DEPLOYMENT_API_DOMAIN_TESTING_CAPTURE_TRAEFIK_RULE:=$(shell set -o allexport; \
 	source $(REPO_CONFIG_LOCATION); \
 	DEPLOYMENT_API_DOMAIN_TESTING_CAPTURE_TRAEFIK_RULE="Host(\`testing.$$API_DOMAIN\`) && PathPrefix(\`/\`)"; \
 	if [ ! -z "$${DEPLOYMENT_FQDNS}" ]; then \
@@ -161,13 +161,13 @@ export DEPLOYMENT_API_DOMAIN_TESTING_CAPTURE_TRAEFIK_RULE=$(shell set -o allexpo
 	set +o allexport; )
 
 # Determine host machine IP
-export MACHINE_IP = $(shell source $(realpath $(REPO_BASE_DIR)/scripts/portable.sh) && get_this_private_ip)
+export MACHINE_IP:=$(shell source $(realpath $(REPO_BASE_DIR)/scripts/portable.sh) && get_this_private_ip)
 
 # Docker secret ID for self-signed cert deplyent
-export DIRECTOR_SELF_SIGNED_SSL_SECRET_ID = $(shell if ! docker secret ls | grep -w rootca.crt >/dev/null; then echo VAR_NOT_SET; else docker secret ls | grep rootca.crt | cut -d " " -f1; fi;)
+export DIRECTOR_SELF_SIGNED_SSL_SECRET_ID:=$(shell if ! docker secret ls | grep -w rootca.crt >/dev/null; then echo VAR_NOT_SET; else docker secret ls | grep rootca.crt | cut -d " " -f1; fi;)
 
 # Generate hashed traefik password
-export TRAEFIK_PASSWORD=$(shell source $(REPO_CONFIG_LOCATION); docker run --rm --entrypoint htpasswd registry:2.6 -nb "$$SERVICES_USER" "$$SERVICES_PASSWORD" | cut -d ':' -f2)
+export TRAEFIK_PASSWORD:=$(shell source $(REPO_CONFIG_LOCATION); docker run --rm --entrypoint htpasswd registry:2.6 -nb "$$SERVICES_USER" "$$SERVICES_PASSWORD" | cut -d ':' -f2)
 
 .PHONY: help
 # thanks to https://marmelab.com/blog/2016/02/29/auto-documented-makefile.html

--- a/scripts/portable.sh
+++ b/scripts/portable.sh
@@ -3,12 +3,16 @@
 # Defines a series of util functions and aliases to be used to overcome compatibility issues with Mac
 
 # Return the current machine's IP
+# Don't use `hostname -I`. `hostname` is part of net-tools, a package universally regarded as old and unmaintained.
+# Modern GNU/Linux distributions use the up-to-date implementation from GNU/inetutils
+# However, debian contributor Miachael Meskes has decided to code a dedicated, different `hostname` for debian, which follows different versioning schemes and
+# is incompatible with the "official" one from GNU. The CLI option `-I` is not supported by the GNU/inetutils's hostname.
 get_this_private_ip()
 {
     if [[ "$OSTYPE" == "darwin"* ]]; then
         ipconfig getifaddr en0
     else
-        hostname -I | cut -d ' ' -f1
+        hostname -i | cut -d ' ' -f1
     fi
 }
 

--- a/services/monitoring/grafana/scripts/export.py
+++ b/services/monitoring/grafana/scripts/export.py
@@ -10,7 +10,11 @@ import typer
 from environs import Env
 
 repo_config_location = os.getenv("REPO_CONFIG_LOCATION")
-assert repo_config_location is not None
+try:
+    assert repo_config_location is not None
+except Exception:
+    print("ERROR: Env-Var REPO_CONFIG_LOCATION not set.")
+    exit(1)
 if "\n" in repo_config_location:
     repo_config_location = repo_config_location.split("\n")[0]
 


### PR DESCRIPTION
## What do these changes do?
### Makefile variable issues
Both @sanderegg and me were unable to run a simple `make` command in this repository. The issue was fixed for me by setting make-variables with `:=` syntax instead of `=`. 

#### `:=` is the "Simple or Immediate Assignment" 
This operator assigns a value to a variable and immediately expands it. The value is fixed at the time of assignment and does not change even if other variables it depends on change later.


#### `=` is the Recursive Assignment:
Behavior: This operator assigns a value to a variable, but the value is not immediately expanded. Instead, the value is expanded each time the variable is used.


(Explanations in this text by LLMs, no factchecking, hallucination warning,)

### `hostname` issues 
In the `common.Makefile` a helper functinon to determine the private-ip of the machine that the command runs on is used. This function calls the linux binary `hostname` in a  shell-call. It turns out that there are multiple implementations of `hostname` that have *different versioning schemes` and are `incompatabile with each other`.

The `hostname` command originally is part of the old `net-tools` package, which is pretty much considered outdated and unmaintained these days. Most modern GNU/Linux distributions have moved on to a newer version provided by GNU/inetutils (see: https://archlinux.org/news/hostname-utility-moved-from-net-tools-to-inetutils/, https://forum.archlinux.de/d/19944-command-not-found-hostname/3 ). Now, here's where it gets a bit tricky. Over in the Debian world, a contributor named Michael Meskes has created a special version of the `hostname` command just for Debian (see https://net-tools.sourceforge.io/ , https://metadata.ftp-master.debian.org/changelogs//main/h/hostname/hostname_3.23+nmu1_changelog ). This version has its own versioning scheme and isn't compatible with the "official" GNU/inetutils version. One big difference is that the `-I` option (which shows all IP addresses of the host) isn't supported by the GNU/inetutils or the original `net-tools` version of `hostname`. So, if you rely on `hostname -I`, you might run into compatibility issues or unexpected behavior, especially if your script ends up running on different systems. To keep things smooth and avoid any headaches, I propose to instead use the `-i` argument, that works well for me.


## Related issue/s
https://github.com/ITISFoundation/osparc-ops-environments/issues/680
## Related PR/s

## Checklist

- [x] I tested and it works
