### PR TITLE
mount efs docker volume to efs-guardian

### DIFF
--- a/services/simcore/docker-compose.deploy.aws.yml
+++ b/services/simcore/docker-compose.deploy.aws.yml
@@ -7,6 +7,10 @@ services:
       placement:
         constraints:
           - node.role == worker
+  efs-guardian:
+    volumes:
+      - efs_volume:/data/efs
+
   clusters-keeper:
     deploy:
       replicas: 1
@@ -58,3 +62,10 @@ services:
   payments:
     deploy:
       replicas: 1
+
+volumes:
+   efs_volume:
+       driver_opts:
+           type: nfs
+           o: addr=${EFS_DNS_NAME},rw,nfsvers=4.1,rsize=1048576,wsize=1048576,hard,timeo=600,retrans=2,noresvport
+           device: :/

--- a/services/simcore/docker-compose.yml
+++ b/services/simcore/docker-compose.yml
@@ -532,6 +532,34 @@ services:
           memory: 128M
           cpus: '0.1'
 
+  efs-guardian:
+    networks:
+      - monitored
+      - public
+    hostname: "{{.Service.Name}}"
+    deploy:
+      replicas: ${SIMCORE_EFS_GUARDIAN_REPLICAS}
+      update_config:
+        parallelism: 2
+        order: start-first
+        failure_action: continue
+        delay: 10s
+      restart_policy:
+        condition: any
+        delay: 5s
+        max_attempts: 3
+        window: 120s
+      placement:
+        constraints:
+          - node.labels.simcore==true
+      resources:
+        limits:
+          memory: 256M
+          cpus: '0.5'
+        reservations:
+          memory: 64M
+          cpus: '0.1'
+
   migration:
     deploy:
       resources:

--- a/services/simcore/docker-compose.yml
+++ b/services/simcore/docker-compose.yml
@@ -533,9 +533,6 @@ services:
           cpus: '0.1'
 
   efs-guardian:
-    networks:
-      - monitored
-      - public
     hostname: "{{.Service.Name}}"
     deploy:
       replicas: ${SIMCORE_EFS_GUARDIAN_REPLICAS}


### PR DESCRIPTION
## What do these changes do?
- mount efs docker volume to efs-guardian
## Related issue/s
- relates https://github.com/ITISFoundation/osparc-issues/issues/1313
- relates https://github.com/ITISFoundation/osparc-simcore/issues/5872

## Related PR/s

## Checklist

- [ ] I tested and it works
