### PR TITLE
skipping validation check for efs guardian

### DIFF
--- a/scripts/deployments/validate_simcore_stack_yml.bash
+++ b/scripts/deployments/validate_simcore_stack_yml.bash
@@ -75,6 +75,10 @@ for service in $($_yq e '.services | keys | .[]' ${COMPOSE_FILE}); do
     if [ "${TARGETNAME}" == "whoami" ]; then
         continue
     fi
+    #  Continue if the service is efs-guardian, as it cannot start because mounting the AWS Distributed Elastic File System to the runner would be required.
+    if [ "${TARGETNAME}" == "efs-guardian" ]; then
+        continue
+    fi
     export TARGET_BINARY="simcore-service"
     echo "Assuming TARGET_BINARY in ${SETTINGS_BINARY_PATH}/${TARGET_BINARY}"
     # Pull image from registry, just in case


### PR DESCRIPTION
## What do these changes do?
 - skipping validation check for efs guardian, as it cannot start because mounting the AWS Distributed Elastic File System to the runner would be required.
## Related issue/s

## Related PR/s

## Checklist

- [ ] I tested and it works
