### PR TITLE
Fix Migration Traefik v2.10-->v2.11: IPWhitelist middleware is now ipallowlist

### DIFF
--- a/services/simcore/docker-compose.yml
+++ b/services/simcore/docker-compose.yml
@@ -785,7 +785,7 @@ services:
         # basic authentication
         - traefik.http.middlewares.${SWARM_STACK_NAME}_auth.basicauth.users=${TRAEFIK_USER}:${TRAEFIK_PASSWORD}
         # OPS IP Whitelist
-        - traefik.http.middlewares.${SWARM_STACK_NAME}_whitelist_ips.ipwhitelist.sourcerange=${TRAEFIK_IPWHITELIST_SOURCERANGE}
+        - traefik.http.middlewares.${SWARM_STACK_NAME}_whitelist_ips.ipallowlist.sourcerange=${TRAEFIK_IPWHITELIST_SOURCERANGE}
       update_config:
         parallelism: 2
         order: start-first

--- a/services/traefik/docker-compose.letsencrypt.dns.yml.j2
+++ b/services/traefik/docker-compose.letsencrypt.dns.yml.j2
@@ -5,7 +5,7 @@ services:
       labels:
         - traefik.http.routers.wwwsecure-catchall.tls.certresolver=myresolver
         - traefik.http.routers.api.tls.certresolver=myresolver
-        - traefik.http.middlewares.ops_whitelist_ips.ipwhitelist.sourcerange=${TRAEFIK_IPWHITELIST_SOURCERANGE}
+        - traefik.http.middlewares.ops_whitelist_ips.ipallowlist.sourcerange=${TRAEFIK_IPWHITELIST_SOURCERANGE}
         # What follows is a tested workaround to ensure letsencrypt certificates for products' domains are generated
 {% for j2item in DEPLOYMENT_FQDNS.split(",") + [MACHINE_FQDN] + CERTIFICATE_GENERATION_FQDNS.split(",") %}
 {% if j2item and j2item.replace('@','').replace(' ','').replace('.','').replace('-','').replace('\'','') != ""  %}

--- a/services/traefik/docker-compose.yml.j2
+++ b/services/traefik/docker-compose.yml.j2
@@ -112,7 +112,7 @@ services:
         # gzip compression
         - traefik.http.middlewares.ops_gzip.compress=true
         # ip whitelisting
-        - traefik.http.middlewares.ops_whitelist_ips.ipwhitelist.sourcerange=${TRAEFIK_IPWHITELIST_SOURCERANGE}
+        - traefik.http.middlewares.ops_whitelist_ips.ipallowlist.sourcerange=${TRAEFIK_IPWHITELIST_SOURCERANGE}
         # traefik UI
         - traefik.http.routers.api.service=api@internal
         - traefik.http.routers.api.rule=Host(`${MONITORING_DOMAIN}`) &&


### PR DESCRIPTION
Fixing the traefik V3 warnings in osparc-master-zmt.click

This is related to https://doc.traefik.io/traefik/migration/v2/#ipwhitelist-http

I went through the repo with a non-case-sensitive search for "whitelist" and subsituted where applicable. I hope this is enough.
## What do these changes do?

## Related issue/s

## Related PR/s

## Checklist

- [ ] I tested and it works
