### PR TITLE
OPS Traefik: disable traefik v2 core syntax

### DIFF
--- a/services/traefik/docker-compose.aws.yml
+++ b/services/traefik/docker-compose.aws.yml
@@ -25,7 +25,6 @@ services:
       - "--entryPoints.smtp.address=:25"
       - "--providers.swarm.endpoint=unix:///var/run/docker.sock"
       - "--providers.swarm.exposedByDefault=false"
-      - "--core.defaultRuleSyntax=v2"
       - "--tracing=true"
       - "--tracing.addinternals"
       - "--tracing.otlp=true"

--- a/services/traefik/docker-compose.dalco.yml
+++ b/services/traefik/docker-compose.dalco.yml
@@ -27,7 +27,6 @@ services:
       - "--entryPoints.staging_postgres.address=:5433"
       - "--providers.swarm.endpoint=unix:///var/run/docker.sock"
       - "--providers.swarm.exposedByDefault=false"
-      - "--core.defaultRuleSyntax=v2"
       - "--tracing=true"
       - "--tracing.addinternals"
       - "--tracing.otlp=true"

--- a/services/traefik/docker-compose.letsencrypt.http.yml
+++ b/services/traefik/docker-compose.letsencrypt.http.yml
@@ -19,7 +19,6 @@ services:
       - "--providers.swarm.endpoint=unix:///var/run/docker.sock"
       - "--providers.swarm.exposedByDefault=false"
       - "--providers.swarm.constraints=!LabelRegex(`io.simcore.zone`, `.+`)"
-      - "--core.defaultRuleSyntax=v2"
       - "--tracing=true"
       - "--tracing.addinternals"
       - "--tracing.otlp=true"

--- a/services/traefik/docker-compose.local.yml
+++ b/services/traefik/docker-compose.local.yml
@@ -29,7 +29,6 @@ services:
       - "--providers.swarm.endpoint=unix:///var/run/docker.sock"
       - "--providers.swarm.exposedByDefault=false"
       - "--providers.swarm.constraints=!LabelRegex(`io.simcore.zone`, `${TRAEFIK_SIMCORE_ZONE}`)"
-      - "--core.defaultRuleSyntax=v2"
       - "--tracing=true"
       - "--tracing.addinternals"
       - "--tracing.otlp=true"

--- a/services/traefik/docker-compose.master.yml
+++ b/services/traefik/docker-compose.master.yml
@@ -26,7 +26,6 @@ services:
       - '--entryPoints.smtp.address=:25'
       - '--providers.swarm.endpoint=unix:///var/run/docker.sock'
       - '--providers.swarm.exposedByDefault=false'
-      - "--core.defaultRuleSyntax=v2"
       - "--tracing=true"
       - "--tracing.addinternals"
       - "--tracing.otlp=true"

--- a/services/traefik/docker-compose.public.yml
+++ b/services/traefik/docker-compose.public.yml
@@ -27,7 +27,6 @@ services:
       - "--entryPoints.smtp.address=:25"
       - "--providers.swarm.endpoint=unix:///var/run/docker.sock"
       - "--providers.swarm.exposedByDefault=false"
-      - "--core.defaultRuleSyntax=v2"
       - "--tracing=true"
       - "--tracing.addinternals"
       - "--tracing.otlp=true"

--- a/services/traefik/docker-compose.yml.j2
+++ b/services/traefik/docker-compose.yml.j2
@@ -31,7 +31,6 @@ services:
       - "--providers.swarm.exposedByDefault=false"
       # so that internal services are not picked up
       - "--providers.swarm.constraints=!LabelRegex(`io.simcore.zone`, `${TRAEFIK_SIMCORE_ZONE}`)"
-      - "--core.defaultRuleSyntax=v2"
       - "--tracing=true"
       - "--tracing.addinternals"
       - "--tracing.otlp=true"


### PR DESCRIPTION
## What do these changes do?
Disable core v2 syntax. This fixed regex in simcore traefik but was forgotten in ops traefik. Disabling v2 core syntax should fix www redirection.

## Related issue/s

## Related PR/s

## Checklist
- [ ] I tested and it works
