### PR TITLE
Bump portainer_portainer memory limit to 1G

### DIFF
--- a/services/portainer/docker-compose.yml
+++ b/services/portainer/docker-compose.yml
@@ -45,7 +45,7 @@ services:
       resources:
         limits:
           cpus: "2"
-          memory: 250M
+          memory: 1G
         reservations:
           cpus: "0.1"
           memory: 128M


### PR DESCRIPTION
## What do these changes do?
After the minor version bump Portainer requires more memory 

fyi: @pcrespov @mguidon 

## Related issue/s

## Related PR/s
* https://github.com/ITISFoundation/osparc-ops-environments/pull/738

## Checklist
- [X] I tested and it works
