### PR TITLE
AWS Deployments: close redis external port

### DIFF
--- a/services/simcore/docker-compose.deploy.aws.yml
+++ b/services/simcore/docker-compose.deploy.aws.yml
@@ -65,19 +65,6 @@ services:
     deploy:
       replicas: 3
 
-  redis:
-    deploy:
-      labels:
-        - traefik.enable=true
-        - traefik.docker.network=${PUBLIC_NETWORK}
-        - traefik.tcp.services.${SWARM_STACK_NAME}_redis.loadBalancer.server.port=6379
-        - traefik.tcp.routers.redis.service=${SWARM_STACK_NAME}_redis
-        - traefik.tcp.routers.redis.entrypoints=redis
-        - traefik.tcp.routers.redis.tls=false
-        - traefik.tcp.routers.redis.rule=ClientIP(`10.0.0.0/8`) || ClientIP(`172.16.0.0/12`) || ClientIP(`192.168.0.0/16`)
-    networks:
-      - public
-
 volumes:
    efs_volume:
        driver_opts:

--- a/services/traefik/docker-compose.aws.yml
+++ b/services/traefik/docker-compose.aws.yml
@@ -34,11 +34,6 @@ services:
       - "--entryPoints.https.forwardedHeaders.insecure"
       - "--providers.file.directory=/etc/traefik/"
       - "--providers.file.watch=true"
-      - '--entryPoints.redis.address=:6379'
-    ports:
-      - target: 6379
-        published: 31379
-        mode: host
     environment:
       - AWS_ACCESS_KEY_ID=${ROUTE53_DNS_CHALLANGE_ACCESS_KEY}
       - AWS_SECRET_ACCESS_KEY=${ROUTE53_DNS_CHALLANGE_SECRET_KEY}


### PR DESCRIPTION
## What do these changes do?
Do not expose self-hosted Redis. There is no need since we only need it for AWS Master which now uses AWS-hosted Redis

## Related issue/s
* https://github.com/ITISFoundation/osparc-ops-environments/issues/241

## Related PR/s

## Checklist

- [ ] I tested and it works
