### PR TITLE
Adds SIMCORE_DATCORE_ADAPTER_REPLICAS for datcore-adapter

### DIFF
--- a/services/simcore/docker-compose.deploy.aws.yml
+++ b/services/simcore/docker-compose.deploy.aws.yml
@@ -2,11 +2,14 @@ services:
   agent:
     volumes:
       - /docker/volumes/:/docker/volumes/
+
+
   dask-sidecar:
     deploy:
       placement:
         constraints:
           - node.role == worker
+
   efs-guardian:
     volumes:
       - efs_volume:/data/efs
@@ -19,6 +22,7 @@ services:
       replicas: 3
   static-webserver:
     hostname: "{{.Node.Hostname}}-{{.Service.Name}}"
+
   postgres:
     deploy:
       replicas: 0

--- a/services/simcore/docker-compose.deploy.local.yml
+++ b/services/simcore/docker-compose.deploy.local.yml
@@ -67,9 +67,6 @@ services:
   rabbit:
     deploy:
       replicas: 1
-  datcore-adapter:
-    deploy:
-      replicas: 0
   redis:
     deploy:
       replicas: 1

--- a/services/simcore/docker-compose.deploy.public.yml
+++ b/services/simcore/docker-compose.deploy.public.yml
@@ -9,9 +9,7 @@ services:
       placement:
         constraints:
           - node.labels.postgres==true
-  datcore-adapter:
-    deploy:
-      replicas: 0
+
   resource-usage-tracker:
     deploy:
       replicas: 3

--- a/services/simcore/docker-compose.yml
+++ b/services/simcore/docker-compose.yml
@@ -511,6 +511,7 @@ services:
 
   datcore-adapter:
     deploy:
+      replicas: ${SIMCORE_DATCORE_ADAPTER_REPLICAS}
       update_config:
         parallelism: 2
         order: start-first


### PR DESCRIPTION
## What do these changes do?

Adds SIMCORE_DATCORE_ADAPTER_REPLICAS to control replicas of `datcore-adapter` service


## Related PR/s

- MUST merge first osparc-configs in https://git.speag.com/oSparc/osparc-ops-deployment-configuration/-/merge_requests/937

