### PR TITLE
jaeger: use ops node label constraint

### DIFF
--- a/services/jaeger/Makefile
+++ b/services/jaeger/Makefile
@@ -24,16 +24,14 @@ up-letsencrypt-dns: .init .env ${TEMP_COMPOSE}-letsencrypt-dns
 	@docker stack deploy --with-registry-auth --prune --compose-file ${TEMP_COMPOSE}-letsencrypt-dns ${STACK_NAME}
 
 .PHONY: up-dalco ## Deploys jaeger stack for Dalco Cluster
-up-dalco: .init .env ${TEMP_COMPOSE}-dalco
-	@docker stack deploy --with-registry-auth --prune --compose-file ${TEMP_COMPOSE}-dalco ${STACK_NAME}
+up-dalco: up
 
 .PHONY: up-aws ## Deploys jaeger stack for aws
 up-aws: .init .env ${TEMP_COMPOSE}-aws  ## Deploys jaeger stack in aws
 	@docker stack deploy --with-registry-auth --prune --compose-file ${TEMP_COMPOSE}-aws ${STACK_NAME}
 
 .PHONY: up-master ## Deploys jaeger stack for master Cluster
-up-master: .init .env ${TEMP_COMPOSE}-master
-	@docker stack deploy --with-registry-auth --prune --compose-file ${TEMP_COMPOSE}-master ${STACK_NAME}
+up-master: up
 
 .PHONY: up-public ## Deploys jaeger stack for public acess deploy
 up-public: up-dalco
@@ -54,14 +52,6 @@ ${TEMP_COMPOSE}-letsencrypt-http: docker-compose.yml docker-compose.letsencrypt.
 .PHONY: ${TEMP_COMPOSE}-letsencrypt-dns
 ${TEMP_COMPOSE}-letsencrypt-dns: docker-compose.yml docker-compose.letsencrypt.dns.yml
 	@${REPO_BASE_DIR}/scripts/docker-stack-config.bash $< docker-compose.letsencrypt.dns.yml > $@
-
-.PHONY: ${TEMP_COMPOSE}-dalco
-${TEMP_COMPOSE}-dalco: docker-compose.yml docker-compose.dalco.yml
-	@${REPO_BASE_DIR}/scripts/docker-stack-config.bash $< docker-compose.dalco.yml > $@
-
-.PHONY: ${TEMP_COMPOSE}-master
-${TEMP_COMPOSE}-master: docker-compose.yml docker-compose.master.yml
-	@${REPO_BASE_DIR}/scripts/docker-stack-config.bash $< docker-compose.master.yml > $@
 
 .PHONY: ${TEMP_COMPOSE}-aws
 ${TEMP_COMPOSE}-aws: docker-compose.yml docker-compose.aws.yml

--- a/services/jaeger/docker-compose.aws.yml
+++ b/services/jaeger/docker-compose.aws.yml
@@ -3,7 +3,3 @@ services:
   jaeger:
     dns: # Add this always for AWS, otherwise we get "No such image: " for docker services
       8.8.8.8
-    deploy:
-      placement:
-        constraints:
-          - node.labels.jaeger==true

--- a/services/jaeger/docker-compose.dalco.yml
+++ b/services/jaeger/docker-compose.dalco.yml
@@ -1,7 +1,0 @@
-version: "3.7"
-services:
-  jaeger:
-    deploy:
-      placement:
-        constraints:
-          - node.labels.jaeger==true

--- a/services/jaeger/docker-compose.master.yml
+++ b/services/jaeger/docker-compose.master.yml
@@ -1,7 +1,0 @@
-version: "3.7"
-services:
-  jaeger:
-    deploy:
-      placement:
-        constraints:
-          - node.labels.jaeger==true

--- a/services/jaeger/docker-compose.yml
+++ b/services/jaeger/docker-compose.yml
@@ -14,6 +14,9 @@ services:
     environment:
       MEMORY_MAX_TRACES: 10000
     deploy:
+      placement:
+        constraints:
+          - node.labels.ops==true
       labels:
         - traefik.enable=true
         - traefik.docker.network=${PUBLIC_NETWORK}
@@ -39,6 +42,10 @@ services:
     hostname: "{{.Node.Hostname}}-{{.Task.Slot}}"
     command:
       - "--config=/etc/otel/config.yaml"
+    deploy:
+      placement:
+        constraints:
+          - node.labels.ops==true
     ports:
       - "4318:4318"  # OTLP HTTP receiver
     networks:


### PR DESCRIPTION
## What do these changes do?

Avoid using specific `jaeger` node label since there is no need to bound jaeger to a node. `ops` node labels will suffice and will make service more restartable by using more generic `ops` node label

## Related issue/s
* https://github.com/ITISFoundation/osparc-ops-environments/issues/747

## Related PR/s

## Checklist
- [X] I tested and it works
