### PR TITLE
Kubernets: assign all pods to nodes

### DIFF
--- a/charts/adminer/values.yaml.gotmpl
+++ b/charts/adminer/values.yaml.gotmpl
@@ -101,6 +101,7 @@ volumeMounts: []
 #   mountPath: "/etc/foo"
 #   readOnly: true
 
-nodeSelector: {}
+nodeSelector:
+  ops: "true"
 
 tolerations: []

--- a/charts/cert-manager/values.common.yaml.gotmpl
+++ b/charts/cert-manager/values.common.yaml.gotmpl
@@ -1,3 +1,6 @@
 crds:
   enabled: true
   keep: true
+
+nodeSelector:
+  ops: "true"

--- a/charts/simcore-charts/resource-usage-tracker/values.yaml.gotmpl
+++ b/charts/simcore-charts/resource-usage-tracker/values.yaml.gotmpl
@@ -91,7 +91,8 @@ volumeMounts: []
 #   mountPath: "/etc/foo"
 #   readOnly: true
 
-nodeSelector: {}
+nodeSelector:
+  simcore: "true"
 
 tolerations: []
 

--- a/charts/traefik/values.common.yaml.gotmpl
+++ b/charts/traefik/values.common.yaml.gotmpl
@@ -31,6 +31,7 @@ affinity:  # https://github.com/traefik/traefik-helm-chart/blob/v28.2.0/traefik/
     requiredDuringSchedulingIgnoredDuringExecution:
       - labelSelector:
           matchLabels:
+            # https://stackoverflow.com/a/51326166/12124525
             app.kubernetes.io/name: '{{`{{ template "traefik.name" . }}`}}'
             app.kubernetes.io/instance: '{{ .Release.Name }}'
         topologyKey: kubernetes.io/hostname

--- a/charts/traefik/values.common.yaml.gotmpl
+++ b/charts/traefik/values.common.yaml.gotmpl
@@ -1,6 +1,9 @@
 additionalArguments:
   - "--api.insecure=true"
 
+deployment:
+  kind: DaemonSet
+
 ingressRoute:
   dashboard:
     enabled: false
@@ -19,3 +22,15 @@ ports:
     nodePort: 32080
   websecure:
     nodePort: 32443
+
+nodeSelector:
+  node-role.kubernetes.io/control-plane: "" # in some cases may require tolerations
+
+affinity:  # https://github.com/traefik/traefik-helm-chart/blob/v28.2.0/traefik/values.yaml#L838
+  podAntiAffinity:
+    requiredDuringSchedulingIgnoredDuringExecution:
+      - labelSelector:
+          matchLabels:
+            app.kubernetes.io/name: '{{`{{ template "traefik.name" . }}`}}'
+            app.kubernetes.io/instance: '{{ .Release.Name }}'
+        topologyKey: kubernetes.io/hostname


### PR DESCRIPTION
## What do these changes do?
Add node label constraints to all charts

## Related issue/s
* https://github.com/ITISFoundation/osparc-ops-environments/issues/805

## Related PR/s
* https://git.speag.com/oSparc/osparc-ops-deployment-configuration/-/merge_requests/960

## Checklist
- [X] I tested and it works
