### PR TITLE
Add k8s portainer

### DIFF
--- a/charts/adminer/values.yaml.gotmpl
+++ b/charts/adminer/values.yaml.gotmpl
@@ -52,6 +52,7 @@ ingress:
     namespace: {{ .Release.Namespace }}
     cert-manager.io/cluster-issuer: "cert-issuer"
     traefik.ingress.kubernetes.io/router.entrypoints: websecure
+    traefik.ingress.kubernetes.io/router.middlewares: traefik-traefik-basic-auth@kubernetescrd  # namespace + middleware name
   tls:
     - hosts:
         - {{ requiredEnv "K8S_MONITORING_FQDN" }}

--- a/charts/portainer/values.yaml.gotmpl
+++ b/charts/portainer/values.yaml.gotmpl
@@ -1,0 +1,68 @@
+# Default values for adminer.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+replicaCount: 1
+
+image:
+  repository: portainer/portainer-ce
+  pullPolicy: IfNotPresent
+
+imagePullSecrets: []
+nameOverride: ""
+fullnameOverride: ""
+
+serviceAccount:
+  # Annotations to add to the service account
+  annotations: {}
+  # The name of the service account to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name: portainer-sa-clusteradmin
+
+podAnnotations: {}
+podLabels: {}
+
+podSecurityContext:
+  {}
+
+securityContext:
+  {}
+
+service:
+  type: "ClusterIP"
+  port: 9000
+
+ingress:
+  enabled: true
+  className: ""
+  annotations:
+    namespace: {{ .Release.Namespace }}
+    cert-manager.io/cluster-issuer: "cert-issuer"
+    traefik.ingress.kubernetes.io/router.entrypoints: websecure
+    traefik.ingress.kubernetes.io/router.middlewares: traefik-traefik-basic-auth@kubernetescrd,traefik-portainer-strip-prefix@kubernetescrd  # namespace + middleware name
+  tls:
+    - hosts:
+        - {{ requiredEnv "K8S_MONITORING_FQDN" }}
+      secretName: monitoring-tls
+  hosts:
+    - host: {{ requiredEnv "K8S_MONITORING_FQDN" }}
+      paths:
+        - path: /portainer
+          pathType: Prefix
+          backend:
+            service:
+              name: portainer
+              port:
+                number: 9000
+
+
+resources:
+  limits:
+    cpu: 2
+    memory: 1024Mi
+  requests:
+    cpu: 0.1
+    memory: 128Mi
+
+nodeSelector:
+  ops: "true"

--- a/charts/traefik/values.insecure.yaml.gotmpl
+++ b/charts/traefik/values.insecure.yaml.gotmpl
@@ -29,6 +29,15 @@ extraObjects:
   spec:
     basicAuth:
       secret: traefik-authorized-users  # https://doc.traefik.io/traefik/middlewares/http/basicauth/#users
+- apiVersion: traefik.io/v1alpha1
+  kind: Middleware
+  metadata:
+    name: portainer-strip-prefix
+    namespace: {{.Release.Namespace}}
+  spec:
+    stripPrefix:
+      prefixes:
+      - /portainer
 - apiVersion: networking.k8s.io/v1
   kind: Ingress
   metadata:

--- a/charts/traefik/values.secure.yaml.gotmpl
+++ b/charts/traefik/values.secure.yaml.gotmpl
@@ -35,10 +35,19 @@ extraObjects:
   kind: Middleware
   metadata:
     name: traefik-basic-auth
+    namespace: {{.Release.Namespace}}
   spec:
     basicAuth:
       secret: traefik-authorized-users  # https://doc.traefik.io/traefik/middlewares/http/basicauth/#users
-
+- apiVersion: traefik.io/v1alpha1
+  kind: Middleware
+  metadata:
+    name: portainer-strip-prefix
+    namespace: {{.Release.Namespace}}
+  spec:
+    stripPrefix:
+      prefixes:
+      - /portainer
 - apiVersion: traefik.io/v1alpha1
   kind: Middleware
   metadata:


### PR DESCRIPTION
## What do these changes do?
Adds k8s portainer to k8s.

~~This will require a sister-PR in osparc-config/e2e-ops for an e2e test before it is merged.~~ is linked below

Bonus:
- Adds basicath for adminer. Might actually not be desirable, I can remove it as well.

Potential improvements are:
- Can the portainer login/password (which is currently manually created during first login) be managed in helmfile gotmpl files, taking the env-vars `PORTAINER_USER` and `PORTAINER_PASSWORD` from `repo.config.template`? This seems not immedeatly possible, see discussions in https://github.com/portainer/k8s/pull/72 and https://github.com/portainer/k8s/pull/71
- We duplicate the strip regex traefik middleware. Can this be avoided?
## Related issue/s
https://github.com/ITISFoundation/osparc-ops-environments/issues/819
## Related PR/s
https://git.speag.com/oSparc/osparc-ops-deployment-configuration/-/merge_requests/1017
## Checklist

- [x] I tested and it works
