### PR TITLE
Raise simcore agent memory limit

### DIFF
--- a/services/simcore/docker-compose.yml
+++ b/services/simcore/docker-compose.yml
@@ -79,7 +79,7 @@ services:
           memory: "64M"
         limits:
           cpus: "1.0"
-          memory: "256M"
+          memory: "2G"
     extra_hosts: []
 
   api-server:


### PR DESCRIPTION
## What do these changes do?
Avoid OOM Killing simcore agent while saving volumes

## Related issue/s
- closes https://github.com/ITISFoundation/osparc-ops-environments/issues/847

## Related PR/s

## Checklist
- [ ] I tested and it works
