### PR TITLE
Expose dynamic scheduler UI

### DIFF
--- a/services/simcore/docker-compose.yml
+++ b/services/simcore/docker-compose.yml
@@ -869,6 +869,7 @@ services:
 
   dynamic-schdlr:
     networks:
+      - public
       - monitored
     deploy:
       replicas: 2
@@ -882,6 +883,16 @@ services:
         reservations:
           memory: 50M
           cpus: '0.1'
+      labels:
+        - traefik.enable=true
+        - traefik.docker.network=${PUBLIC_NETWORK}
+        - traefik.http.services.${PREFIX_STACK_NAME}_dynamic_scheduler.loadbalancer.server.port=8000
+        - traefik.http.routers.${PREFIX_STACK_NAME}_dynamic_scheduler.rule=Host(`${MONITORING_DOMAIN}`) && PathPrefix(`/dynamic-scheduler`)
+        - traefik.http.routers.${PREFIX_STACK_NAME}_dynamic_scheduler.entrypoints=https
+        - traefik.http.routers.${PREFIX_STACK_NAME}_dynamic_scheduler.tls=true
+        - traefik.http.middlewares.${PREFIX_STACK_NAME}_dynamic_scheduler_replace_regex.replacepathregex.regex=^/dynamic-scheduler/(.*)$$
+        - traefik.http.middlewares.${PREFIX_STACK_NAME}_dynamic_scheduler_replace_regex.replacepathregex.replacement=/$${1}
+        - traefik.http.routers.${PREFIX_STACK_NAME}_dynamic_scheduler.middlewares=${PREFIX_STACK_NAME}_dynamic_scheduler_replace_regex@swarm, ops_gzip@swarm, ops_auth@swarm
 
 volumes:
   rabbit_data:


### PR DESCRIPTION
## What do these changes do?
Expose dynamic scheduler 

## Add e2e ops service tests
- [ ] Master (https://git.speag.com/oSparc/osparc-ops-deployment-configuration/-/merge_requests/1134)
- [ ] STAG (https://git.speag.com/oSparc/osparc-ops-deployment-configuration/-/merge_requests/1135)
- [ ] PROD (https://git.speag.com/oSparc/osparc-ops-deployment-configuration/-/merge_requests/1136)

## Related issue/s
* closes https://github.com/ITISFoundation/osparc-ops-environments/issues/892

## Related PR/s

## Checklist
- [X] I tested and it works

<!--  Extra checks based on use case -->

<!-- New Stack Introduction
- [ ] The Stack has been included in CI Workflow
-->

<!-- New Service Introduction
- [ ] Service has resource limits and reservations
- [ ] Service has placement constraints or is global
- [ ] Service is restartable
- [ ] Service restart is zero-downtime
- [ ] Service is not bound to one specific node (e.g. via files or volumes)
- [ ] Relevant OPS E2E Test are added
- [ ] Service's Public URL is included in maintenance mode -->
