### PR TITLE
Fix traefik domain redirect for empty strings

### DIFF
--- a/services/traefik/docker-compose.yml.j2
+++ b/services/traefik/docker-compose.yml.j2
@@ -150,9 +150,9 @@ services:
         ###
         # Domain redirects
         ###
-{% set redirect_from_domains_list = TRAEFIK_DOMAINS_REDIRECT_FROM.split(',') %}
-{% set redirect_to_domains_list = TRAEFIK_DOMAINS_REDIRECT_TO.split(',') %}
-{% set redirect_is_permanent_list = TRAEFIK_DOMAINS_REDIRECT_IS_PERMANENT.split(',') %}
+{% set redirect_from_domains_list = TRAEFIK_DOMAINS_REDIRECT_FROM.strip().split(',') if TRAEFIK_DOMAINS_REDIRECT_FROM.strip() else [] %}
+{% set redirect_to_domains_list = TRAEFIK_DOMAINS_REDIRECT_TO.strip().split(',') if TRAEFIK_DOMAINS_REDIRECT_TO.strip() else [] %}
+{% set redirect_is_permanent_list = TRAEFIK_DOMAINS_REDIRECT_IS_PERMANENT.strip().split(',') if TRAEFIK_DOMAINS_REDIRECT_IS_PERMANENT.strip() else [] %}
 
 {% for ix in range(redirect_from_domains_list | length) %}
 


### PR DESCRIPTION
## What do these changes do?

## Related issue/s

## Related PR/s

## Checklist
- [ ] I tested and it works

<!--  Extra checks based on use case -->

<!-- New Stack Introduction
- [ ] The Stack has been included in CI Workflow
-->

<!-- New Service Introduction
- [ ] Service has resource limits and reservations
- [ ] Service has placement constraints or is global
- [ ] Service is restartable
- [ ] Service restart is zero-downtime
- [ ] Service is not bound to one specific node (e.g. via files or volumes)
- [ ] Relevant OPS E2E Test are added
- [ ] Service's Public URL is included in maintenance mode -->
