### PR TITLE
Add manual to traefik redirect capture all rule

### DIFF
--- a/services/traefik/j2cli_customization.py
+++ b/services/traefik/j2cli_customization.py
@@ -11,6 +11,7 @@ def _generate_domain_capture_all_rule(domain: str) -> str:
         f"Host(`api.{domain}`)",
         f"Host(`api.testing.{domain}`)",
         f"Host(`testing.{domain}`)",
+        f"Host(`manual.{domain}`)",
     ]
     return " || ".join(rules)
 


### PR DESCRIPTION
## What do these changes do?

## Related issue/s
* https://github.com/ITISFoundation/osparc-ops-environments/issues/875

## Related PR/s
* https://github.com/ITISFoundation/osparc-ops-environments/pull/925

## Checklist
- [X] I tested and it works

<!--  Extra checks based on use case -->

<!-- New Stack Introduction
- [ ] The Stack has been included in CI Workflow
-->

<!-- New Service Introduction
- [ ] Service has resource limits and reservations
- [ ] Service has placement constraints or is global
- [ ] Service is restartable
- [ ] Service restart is zero-downtime
- [ ] Service is not bound to one specific node (e.g. via files or volumes)
- [ ] Relevant OPS E2E Test are added
- [ ] Service's Public URL is included in maintenance mode -->
