### PR TITLE
Add fallback nginx to serve "something went wrong"

### DIFF
--- a/services/traefik/config/api/503.json
+++ b/services/traefik/config/api/503.json
@@ -1,0 +1,3 @@
+{
+    "errors": ["Oops! Something went wrong. Please try again."]
+}

--- a/services/traefik/config/api/default.conf
+++ b/services/traefik/config/api/default.conf
@@ -1,0 +1,19 @@
+server {
+    listen       80;
+    listen  [::]:80;
+    server_name  localhost;
+
+    error_page 503 /503.json;
+
+    location / {
+        return 503;
+    }
+
+    location = /503.json {
+        default_type application/json;
+
+        add_header Retry-After "10" always;  # https://serverfault.com/a/647552
+
+        root /usr/share/nginx/api;
+    }
+}

--- a/services/traefik/config/web/503.html
+++ b/services/traefik/config/web/503.html
@@ -1,0 +1,72 @@
+<html style="overflow: hidden; margin: 0px; padding: 0px; height: 100%; width: 100%;"><head>
+    <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
+
+    <!-- Setup the viewport for mobile and desktop environments -->
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=0, minimum-scale=1.0, maximum-scale=1.0">
+
+    <!-- Configure linking of this application to the home screen of mobile devices -->
+    <meta name="apple-mobile-web-app-title" content="${name}">
+    <meta name="mobile-web-app-capable" content="yes">
+    <meta name="apple-mobile-web-app-capable" content="yes">
+    <meta name="apple-mobile-web-app-status-bar-style" content="default">
+    <meta name="msapplication-tap-highlight" content="no">
+
+    <!-- Disable chrome translation requests and automatic phone number linking -->
+    <meta name="google" value="notranslate">
+
+    <style>
+      body {
+        padding: 0px;
+        margin: 0px;
+        width: 100%;
+        height: 100%;
+        position: fixed;
+        -webkit-touch-callout: none !important;
+        overflow: hidden;
+        background-color: #202020;
+      }
+
+      .container {
+        position: relative;
+        text-align: center;
+        color: white;
+      }
+      .box {
+        /* 50% darker than the main color bg */
+        opacity: .7;
+        padding-bottom: 20px;
+        padding-top: 1px;
+        padding-right: 40px;
+        padding-left: 40px;
+      }
+      .centered {
+        position: absolute;
+        top: 40%;
+        left: 50%;
+        transform: translate(-50%, -50%);
+      }
+      h2 {
+        font-family: "Helvetica";
+        font-size: 2.4em;
+        color: white;
+        text-align: center;
+      }
+    </style>
+
+    <title>Oops</title>
+
+    <noscript>
+      <meta http-equiv="refresh" content="0; url=nojs.html"/>
+    </noscript>
+  <body>
+    <div class="container"></div>
+    <div class="centered">
+      <div class="box">
+        <h2>
+          Oops! Something went wrong.<br>Please try again.
+        </h2>
+      </div>
+    </div>
+  </section>
+</body>

--- a/services/traefik/config/web/default.conf
+++ b/services/traefik/config/web/default.conf
@@ -1,0 +1,19 @@
+server {
+    listen       80;
+    listen  [::]:80;
+    server_name  localhost;
+
+    error_page 503 /503.html;
+
+    location / {
+        return 503;
+    }
+
+    location = /503.html {
+        default_type text/html;
+
+        add_header Retry-After "10" always;  # https://serverfault.com/a/647552
+
+        root /usr/share/nginx/html;
+    }
+}

--- a/services/traefik/docker-compose.yml.j2
+++ b/services/traefik/docker-compose.yml.j2
@@ -204,6 +204,72 @@ services:
     networks:
       - public
 
+  fallback-service-web:
+    image: nginx:1.25.1
+    configs:
+      - source: web_html
+        target: /usr/share/nginx/html/503.html
+      - source: web_nginx_config
+        target: /etc/nginx/conf.d/default.conf
+    networks:
+      - public
+      - monitored
+    deploy:
+      placement:
+        constraints:
+          - node.labels.simcore==true
+      update_config:
+        order: start-first
+      labels:
+          - traefik.enable=true
+          - traefik.docker.network=${PUBLIC_NETWORK}
+          - traefik.http.routers.fallback_html.priority=3
+          - traefik.http.routers.fallback_html.tls=true
+          - traefik.http.routers.fallback_html.rule=Host(`fallback.osparc.local`)
+          - traefik.http.services.fallback_html.loadbalancer.server.port=80
+          - traefik.http.routers.fallback_html.entrypoints=https
+
+  fallback-service-api:
+    image: nginx:1.25.1
+    configs:
+      - source: api_json
+        target: /usr/share/nginx/api/503.json
+      - source: api_nginx_config
+        target: /etc/nginx/conf.d/default.conf
+    networks:
+      - public
+      - monitored
+    deploy:
+      placement:
+        constraints:
+          - node.labels.simcore==true
+      update_config:
+        order: start-first
+      labels:
+          - traefik.enable=true
+          - traefik.docker.network=${PUBLIC_NETWORK}
+          - traefik.http.routers.fallback_api.priority=3
+          - traefik.http.routers.fallback_api.tls=true
+          - traefik.http.routers.fallback_api.rule=Host(`fallback-api.osparc.local`)
+          - traefik.http.services.fallback_api.loadbalancer.server.port=80
+          - traefik.http.routers.fallback_api.entrypoints=https
+
+{%- raw %}
+configs:
+  web_html:
+    file: ./config/web/503.html
+    name: web_html_${DOCKER_IMAGE_TAG?error}  # exit with error if not defined
+  api_json:
+    file: ./config/api/503.json
+    name: api_json_${DOCKER_IMAGE_TAG?error}
+  web_nginx_config:
+    file: ./config/web/default.conf
+    name: web_nginx_config_${DOCKER_IMAGE_TAG?error}
+  api_nginx_config:
+    file: ./config/api/default.conf
+    name: api_nginx_config_${DOCKER_IMAGE_TAG?error}
+{% endraw %}
+
 networks:
   public:
     external: true


### PR DESCRIPTION
## What do these changes do?

## Related issue/s
- https://github.com/ITISFoundation/osparc-ops-environments/issues/218
- blocked by https://github.com/ITISFoundation/osparc-ops-environments/issues/949

## Related PR/s

## Checklist
- [ ] I tested and it works

<!--  Extra checks based on use case -->

<!-- New Stack Introduction
- [ ] The Stack has been included in CI Workflow
-->

<!-- New Service Introduction
- [ ] Service has resource limits and reservations
- [ ] Service has placement constraints or is global
- [ ] Service is restartable
- [ ] Service restart is zero-downtime
- [ ] Service is not bound to one specific node (e.g. via files or volumes)
- [ ] Relevant OPS E2E Test are added
- [ ] Service's Public URL is included in maintenance mode -->
