### PR TITLE
Update traefik router hardcoded priorities

### DIFF
--- a/services/admin-panels/docker-compose.yml.j2
+++ b/services/admin-panels/docker-compose.yml.j2
@@ -89,7 +89,7 @@ services:
         - traefik.http.services.adminpanels.loadbalancer.server.port=8888
         - traefik.http.routers.adminpanels.rule=Host(`${ADMINPANELS_DOMAIN}`)
         - traefik.http.routers.adminpanels.entrypoints=https
-        - traefik.http.routers.adminpanels.priority=1
+        - traefik.http.routers.adminpanels.priority=3
         - traefik.http.routers.adminpanels.tls=true
         - traefik.http.routers.adminpanels.middlewares=ops_whitelist_ips@swarm, ops_gzip@swarm
       placement:

--- a/services/admin-panels/docker-compose.yml.j2
+++ b/services/admin-panels/docker-compose.yml.j2
@@ -89,7 +89,6 @@ services:
         - traefik.http.services.adminpanels.loadbalancer.server.port=8888
         - traefik.http.routers.adminpanels.rule=Host(`${ADMINPANELS_DOMAIN}`)
         - traefik.http.routers.adminpanels.entrypoints=https
-        - traefik.http.routers.adminpanels.priority=3
         - traefik.http.routers.adminpanels.tls=true
         - traefik.http.routers.adminpanels.middlewares=ops_whitelist_ips@swarm, ops_gzip@swarm
       placement:

--- a/services/registry/docker-compose.yml.j2
+++ b/services/registry/docker-compose.yml.j2
@@ -54,7 +54,6 @@ services:
         - traefik.http.routers.registry.rule=Host(`${REGISTRY_DOMAIN}`)
         - traefik.http.routers.registry.entrypoints=https
         - traefik.http.routers.registry.tls=true
-        - traefik.http.routers.registry.priority=10
         - traefik.http.routers.registry.middlewares=ops_gzip@swarm, ops_auth@swarm
         - prometheus-job=registry
         - prometheus-port=5001

--- a/services/simcore/docker-compose.yml
+++ b/services/simcore/docker-compose.yml
@@ -94,7 +94,7 @@ services:
         - traefik.http.routers.${SWARM_STACK_NAME}_apiserver_swagger.service=${SWARM_STACK_NAME}_api-server
         - traefik.http.routers.${SWARM_STACK_NAME}_apiserver_swagger.rule=PathPrefix(`/dev/`)
         - traefik.http.routers.${SWARM_STACK_NAME}_apiserver_swagger.entrypoints=simcore_api
-        - traefik.http.routers.${SWARM_STACK_NAME}_apiserver_swagger.priority=2
+        - traefik.http.routers.${SWARM_STACK_NAME}_apiserver_swagger.priority=6
       update_config:
         parallelism: 2
         order: start-first
@@ -153,7 +153,7 @@ services:
         - traefik.http.routers.${SWARM_STACK_NAME}_static_webserver_freshping.service=${SWARM_STACK_NAME}_static_webserver_freshping
         - traefik.http.services.${SWARM_STACK_NAME}_static_webserver_freshping.loadbalancer.server.port=8000
         - traefik.http.routers.${SWARM_STACK_NAME}_static_webserver_freshping.entrypoints=http
-        - traefik.http.routers.${SWARM_STACK_NAME}_static_webserver_freshping.priority=10 # High number means high priority
+        - traefik.http.routers.${SWARM_STACK_NAME}_static_webserver_freshping.priority=12 # High number means high priority
         - traefik.http.routers.${SWARM_STACK_NAME}_static_webserver_freshping.middlewares=${SWARM_STACK_NAME}_gzip@swarm,${SWARM_STACK_NAME}_static_webserver_retry,${SWARM_STACK_NAME}_static_webserver_prefix
       update_config:
         parallelism: 2
@@ -229,7 +229,7 @@ services:
         - traefik.http.routers.${SWARM_STACK_NAME}_webserver_swagger.middlewares=${SWARM_STACK_NAME}_gzip@swarm, ${SWARM_STACK_NAME_NO_HYPHEN}_sslheader
         - traefik.http.routers.${SWARM_STACK_NAME}_webserver_swagger.rule=PathPrefix(`/dev/`)
         - traefik.http.routers.${SWARM_STACK_NAME}_webserver_swagger.entrypoints=http
-        - traefik.http.routers.${SWARM_STACK_NAME}_webserver_swagger.priority=2
+        - traefik.http.routers.${SWARM_STACK_NAME}_webserver_swagger.priority=6
         - traefik.http.middlewares.${SWARM_STACK_NAME_NO_HYPHEN}_webserver_swagger_auth.basicauth.users=${TRAEFIK_USER}:${TRAEFIK_PASSWORD}
         - traefik.http.routers.${SWARM_STACK_NAME}_webserver_swagger.middlewares=${SWARM_STACK_NAME_NO_HYPHEN}_webserver_swagger_auth, ${SWARM_STACK_NAME_NO_HYPHEN}_sslheader
       update_config: &webserver_update_config
@@ -726,7 +726,7 @@ services:
         - traefik.http.routers.${SWARM_STACK_NAME}_simcore_http.middlewares=ops_gzip@swarm, ops_sslheader@swarm, ops_ratelimit@swarm
         - traefik.http.routers.${SWARM_STACK_NAME}_simcore_http.service=${SWARM_STACK_NAME}_simcore_http
         - traefik.http.routers.${SWARM_STACK_NAME}_simcore_http.rule=((${DEPLOYMENT_FQDNS_CAPTURE_TRAEFIK_RULE_CATCHALL}) && PathPrefix(`/`)) || ( (PathPrefix(`/dashboard`) || PathPrefix(`/api`) ) && Host(`traefikdashboard.${MACHINE_FQDN}`))
-        - traefik.http.routers.${SWARM_STACK_NAME}_simcore_http.priority=1 # Lowest possible priority, maintenance page takes priority "2" (higher, maintenance page has precedent) if it is up
+        - traefik.http.routers.${SWARM_STACK_NAME}_simcore_http.priority=3
         # oSparc publicAPI
         - traefik.http.routers.${SWARM_STACK_NAME}_simcore_api.rule=(${DEPLOYMENT_API_DOMAIN_CAPTURE_TRAEFIK_RULE}) && PathPrefix(`/`)
         - traefik.http.routers.${SWARM_STACK_NAME}_simcore_api.entrypoints=https
@@ -785,7 +785,7 @@ services:
         - traefik.http.routers.${SWARM_STACK_NAME}_traefik_api.service=api@internal
         - traefik.http.routers.${SWARM_STACK_NAME}_traefik_api.rule=(PathPrefix(`/dashboard`) || PathPrefix(`/api`) ) && Host(`traefikdashboard.${MACHINE_FQDN}`)
         - traefik.http.routers.${SWARM_STACK_NAME}_traefik_api.entrypoints=http
-        - traefik.http.routers.${SWARM_STACK_NAME}_traefik_api.priority=2
+        - traefik.http.routers.${SWARM_STACK_NAME}_traefik_api.priority=6
         - traefik.http.routers.${SWARM_STACK_NAME}_traefik_api.middlewares=${SWARM_STACK_NAME}_auth@swarm, ${SWARM_STACK_NAME}_whitelist_ips@swarm
         - traefik.http.services.${SWARM_STACK_NAME}_traefik_api.loadbalancer.server.port=8080
         # Middlewares
@@ -829,7 +829,7 @@ services:
         - traefik.http.services.${SWARM_STACK_NAME}_whoami.loadbalancer.server.port=80
         - traefik.http.routers.${SWARM_STACK_NAME}_whoami.rule=PathPrefix(`/whoami`)
         - traefik.http.routers.${SWARM_STACK_NAME}_whoami.entrypoints=http
-        - traefik.http.routers.${SWARM_STACK_NAME}_whoami.priority=2
+        - traefik.http.routers.${SWARM_STACK_NAME}_whoami.priority=6
         - traefik.http.routers.${SWARM_STACK_NAME}_whoami.middlewares=${SWARM_STACK_NAME}_auth@swarm,${SWARM_STACK_NAME}_gzip@swarm
       update_config:
         parallelism: 2


### PR DESCRIPTION
## What do these changes do?
* Update traefik router hardcoded priorities according to the rules below
  - 1 --> 3
  - 2 --> 6
  -  3 --> 9
  - 10 --> 12
* Remove unnecessary priority from `adminpanels` and `registry` service

This PR introduces some space in-between the routers which we can use to flexibly add new routers. It shouldn't break existing priority hierarchy since numbers <13 are still below any other non-hardcoded priorities.

Remarks for future:
* Whenever introducing some priorities to traefik routers (or other similar cases) one better to make them spacious to retain flexibility. This case is a good example why "spacious" approach makes sense

## Related issue/s
* https://github.com/ITISFoundation/osparc-ops-environments/issues/218

## Related PR/s
* https://github.com/ITISFoundation/osparc-simcore/pull/7141
* https://github.com/ITISFoundation/osparc-ops-environments/pull/950

## Checklist
- [ ] I tested and it works

<!--  Extra checks based on use case -->

<!-- New Stack Introduction
- [ ] The Stack has been included in CI Workflow
-->

<!-- New Service Introduction
- [ ] Service has resource limits and reservations
- [ ] Service has placement constraints or is global
- [ ] Service is restartable
- [ ] Service restart is zero-downtime
- [ ] Service is not bound to one specific node (e.g. via files or volumes)
- [ ] Relevant OPS E2E Test are added
- [ ] Service's Public URL is included in maintenance mode -->
