### PR TITLE
Configure redis replicas via ENV

### DIFF
--- a/services/simcore/docker-compose.deploy.local.yml
+++ b/services/simcore/docker-compose.deploy.local.yml
@@ -66,9 +66,6 @@ services:
   rabbit:
     deploy:
       replicas: 1
-  redis:
-    deploy:
-      replicas: 1
   traefik:
     command:
       - "--api=true"

--- a/services/simcore/docker-compose.yml
+++ b/services/simcore/docker-compose.yml
@@ -619,6 +619,7 @@ services:
     networks:
       - monitored
     deploy:
+      replicas: ${REDIS_SELF_HOSTED_REPLICAS}
       update_config:
         parallelism: 2
         order: start-first


### PR DESCRIPTION
## What do these changes do?
* Configure redis replicas via ENV
* It lets us disable redis on deployments where we use AWS Redis

## Related issue/s
* https://github.com/ITISFoundation/osparc-ops-environments/issues/807

## Related PR/s
* https://git.speag.com/oSparc/osparc-ops-deployment-configuration/-/merge_requests/1240

## Checklist
- [X] I tested and it works

<!--  Extra checks based on use case -->

<!-- New Stack Introduction
- [ ] The Stack has been included in CI Workflow
-->

<!-- New Service Introduction
- [ ] Service has resource limits and reservations
- [ ] Service has placement constraints or is global
- [ ] Service is restartable
- [ ] Service restart is zero-downtime
- [ ] Service is not bound to one specific node (e.g. via files or volumes)
- [ ] Relevant OPS E2E Test are added
- [ ] Service's Public URL is included in maintenance mode -->
