### PR TITLE
Filestash: remove special docker node label

### DIFF
--- a/services/filestash/Makefile
+++ b/services/filestash/Makefile
@@ -24,19 +24,17 @@ up-letsencrypt-dns: .init .env filestash_config.json ${TEMP_COMPOSE}-letsencrypt
 	@docker stack deploy --with-registry-auth --prune --compose-file ${TEMP_COMPOSE}-letsencrypt-dns ${STACK_NAME}
 
 .PHONY: up-dalco ## Deploys stack for Dalco Cluster
-up-dalco: .init .env filestash_config.json ${TEMP_COMPOSE}-dalco
-	@docker stack deploy --with-registry-auth --prune --compose-file ${TEMP_COMPOSE}-dalco ${STACK_NAME}
+up-dalco: up
 
 .PHONY: up-aws ## Deploys stack on aws
 up-aws: .init .env ${TEMP_COMPOSE}-aws filestash_config.json ## Deploys stack in aws
 	@docker stack deploy --with-registry-auth --prune --compose-file ${TEMP_COMPOSE}-aws ${STACK_NAME}
 
 .PHONY: up-master ## Deploys stack for master Cluster
-up-master: .init .env filestash_config.json ${TEMP_COMPOSE}-master
-	@docker stack deploy --with-registry-auth --prune --compose-file ${TEMP_COMPOSE}-master ${STACK_NAME}
+up-master: up
 
 .PHONY: up-public ## Deploys stack on public
-up-public: up-dalco
+up-public: up
 
 .PHONY: up-local ## Deploys stack on local deployment
 up-local: up
@@ -44,29 +42,20 @@ up-local: up
 # Helpers -------------------------------------------------
 
 .PHONY: ${TEMP_COMPOSE}
-${TEMP_COMPOSE}: docker-compose.yml
+${TEMP_COMPOSE}: docker-compose.yml .env
 	@${REPO_BASE_DIR}/scripts/docker-stack-config.bash -e .env $< > $@
 
 .PHONY: ${TEMP_COMPOSE}-letsencrypt-http
-${TEMP_COMPOSE}-letsencrypt-http: docker-compose.yml docker-compose.letsencrypt.http.yml
+${TEMP_COMPOSE}-letsencrypt-http: docker-compose.yml docker-compose.letsencrypt.http.yml .env
 	@${REPO_BASE_DIR}/scripts/docker-stack-config.bash -e .env $< docker-compose.letsencrypt.http.yml  > $@
 
 .PHONY: ${TEMP_COMPOSE}-letsencrypt-dns
-${TEMP_COMPOSE}-letsencrypt-dns: docker-compose.yml docker-compose.letsencrypt.dns.yml
+${TEMP_COMPOSE}-letsencrypt-dns: docker-compose.yml docker-compose.letsencrypt.dns.yml .env
 	@${REPO_BASE_DIR}/scripts/docker-stack-config.bash -e .env $< docker-compose.letsencrypt.dns.yml  > $@
 
-.PHONY: ${TEMP_COMPOSE}-dalco
-${TEMP_COMPOSE}-dalco: docker-compose.yml docker-compose.dalco.yml
-	@${REPO_BASE_DIR}/scripts/docker-stack-config.bash -e .env $< docker-compose.dalco.yml  > $@
-
-.PHONY: ${TEMP_COMPOSE}-master
-${TEMP_COMPOSE}-master: docker-compose.yml docker-compose.master.yml
-	@${REPO_BASE_DIR}/scripts/docker-stack-config.bash -e .env $< docker-compose.master.yml  > $@
-
 .PHONY: ${TEMP_COMPOSE}-aws
-${TEMP_COMPOSE}-aws: docker-compose.yml docker-compose.aws.yml
+${TEMP_COMPOSE}-aws: docker-compose.yml docker-compose.aws.yml .env
 	@${REPO_BASE_DIR}/scripts/docker-stack-config.bash -e .env $< docker-compose.aws.yml > $@
-
 
 filestash_config.json: .env
 	@set -o allexport; \

--- a/services/filestash/docker-compose.aws.yml
+++ b/services/filestash/docker-compose.aws.yml
@@ -3,7 +3,3 @@ services:
   filestash:
     dns: # Add this always for AWS, otherwise we get "No such image: " for docker services
       8.8.8.8
-    deploy:
-      placement:
-        constraints:
-          - node.labels.filestash==true

--- a/services/filestash/docker-compose.dalco.yml
+++ b/services/filestash/docker-compose.dalco.yml
@@ -1,7 +1,0 @@
-version: "3.7"
-services:
-  filestash:
-    deploy:
-      placement:
-        constraints:
-          - node.labels.filestash==true

--- a/services/filestash/docker-compose.master.yml
+++ b/services/filestash/docker-compose.master.yml
@@ -1,7 +1,0 @@
-version: "3.7"
-services:
-  filestash:
-    deploy:
-      placement:
-        constraints:
-          - node.labels.filestash==true

--- a/services/filestash/docker-compose.yml
+++ b/services/filestash/docker-compose.yml
@@ -26,6 +26,9 @@ services:
         reservations:
           memory: 32M
           cpus: "0.1"
+      placement:
+        constraints:
+          - node.labels.ops==true
   onlyoffice:
     image: onlyoffice/documentserver:7.4.0
     networks:


### PR DESCRIPTION
## What do these changes do?
Remove `FILESTASH` label as it is not stricly needed and common `OPS` label could be used instead

## Related issue/s
* https://github.com/ITISFoundation/osparc-ops-environments/issues/936

## Related PR/s
- master https://git.speag.com/oSparc/osparc-ops-deployment-configuration/-/merge_requests/1243
- staging https://git.speag.com/oSparc/osparc-ops-deployment-configuration/-/merge_requests/1244
- prod https://git.speag.com/oSparc/osparc-ops-deployment-configuration/-/merge_requests/1245

## Checklist
- [X] I tested and it works

<!--  Extra checks based on use case -->

<!-- New Stack Introduction
- [ ] The Stack has been included in CI Workflow
-->

<!-- New Service Introduction
- [ ] Service has resource limits and reservations
- [ ] Service has placement constraints or is global
- [ ] Service is restartable
- [ ] Service restart is zero-downtime
- [ ] Service is not bound to one specific node (e.g. via files or volumes)
- [ ] Relevant OPS E2E Test are added
- [ ] Service's Public URL is included in maintenance mode -->
