### PR TITLE
Remove docker api proxy from validate simcore settings

### DIFF
--- a/scripts/deployments/validate_simcore_stack_yml.bash
+++ b/scripts/deployments/validate_simcore_stack_yml.bash
@@ -79,6 +79,9 @@ for service in $($_yq e '.services | keys | .[]' ${COMPOSE_FILE}); do
     if [ "${TARGETNAME}" == "efs-guardian" ]; then
         continue
     fi
+    if [ "${TARGETNAME}" == "docker-api-proxy" ]; then
+        continue
+    fi
     export TARGET_BINARY="simcore-service"
     echo "Assuming TARGET_BINARY in ${SETTINGS_BINARY_PATH}/${TARGET_BINARY}"
     # Pull image from registry, just in case


### PR DESCRIPTION
## What do these changes do?
This fixed validate simcore pydantic settings job in Release CI

## Related issue/s

## Related PR/s
* https://github.com/ITISFoundation/osparc-simcore/pull/7070/files

## Checklist
- [ ] I tested and it works

<!--  Extra checks based on use case -->

<!-- New Stack Introduction
- [ ] The Stack has been included in CI Workflow
-->

<!-- New Service Introduction
- [ ] Service has resource limits and reservations
- [ ] Service has placement constraints or is global
- [ ] Service is restartable
- [ ] Service restart is zero-downtime
- [ ] Service is not bound to one specific node (e.g. via files or volumes)
- [ ] Relevant OPS E2E Test are added
- [ ] Service's Public URL is included in maintenance mode -->
