### PR TITLE
Fix postgres router

### DIFF
--- a/services/simcore/docker-compose.deploy.local.yml
+++ b/services/simcore/docker-compose.deploy.local.yml
@@ -104,7 +104,6 @@ services:
       labels:
         # oSparc postgres
         - traefik.tcp.routers.${SWARM_STACK_NAME}_postgresRoute.entrypoints=postgres
-        - traefik.tcp.routers.${SWARM_STACK_NAME}_postgresRoute.entrypoints=${PREFIX_STACK_NAME}_postgres
         - traefik.tcp.routers.${SWARM_STACK_NAME}_postgresRoute.tls=false
         - traefik.tcp.routers.${SWARM_STACK_NAME}_postgresRoute.service=${SWARM_STACK_NAME}_postgresRoute
         - traefik.tcp.services.${SWARM_STACK_NAME}_postgresRoute.loadbalancer.server.port=5432

--- a/services/simcore/docker-compose.deploy.master.yml
+++ b/services/simcore/docker-compose.deploy.master.yml
@@ -63,7 +63,7 @@ services:
         - traefik.tcp.routers.${SWARM_STACK_NAME}_postgresRoute.tls=false
         - traefik.tcp.routers.${SWARM_STACK_NAME}_postgresRoute.service=${SWARM_STACK_NAME}_postgresRoute
         - traefik.tcp.services.${SWARM_STACK_NAME}_postgresRoute.loadbalancer.server.port=5432
-        - traefik.tcp.routers.${SWARM_STACK_NAME}_postgresRoute.rule=ClientIP(`195.176.8.0/24`) || ClientIP(`10.0.0.0/8`) || ClientIP(`172.16.0.0/12`) || ClientIP(`192.168.0.0/16`)
+        - "traefik.tcp.routers.${SWARM_STACK_NAME}_postgresRoute.rule=ClientIP(`195.176.8.0/24`) || ClientIP(`10.0.0.0/8`) || ClientIP(`172.16.0.0/12`) || ClientIP(`192.168.0.0/16`)"
   clusters-keeper:
     deploy:
       replicas: 0

--- a/services/simcore/docker-compose.deploy.master.yml
+++ b/services/simcore/docker-compose.deploy.master.yml
@@ -60,11 +60,10 @@ services:
       labels:
         # oSparc postgres
         - traefik.tcp.routers.${SWARM_STACK_NAME}_postgresRoute.entrypoints=postgres
-        - traefik.tcp.routers.${SWARM_STACK_NAME}_postgresRoute.entrypoints=${PREFIX_STACK_NAME}_postgres
         - traefik.tcp.routers.${SWARM_STACK_NAME}_postgresRoute.tls=false
         - traefik.tcp.routers.${SWARM_STACK_NAME}_postgresRoute.service=${SWARM_STACK_NAME}_postgresRoute
         - traefik.tcp.services.${SWARM_STACK_NAME}_postgresRoute.loadbalancer.server.port=5432
-        - "traefik.tcp.routers.${SWARM_STACK_NAME}_postgresRoute.rule=ClientIP(`195.176.8.0/24`) || ClientIP(`10.0.0.0/8`) || ClientIP(`172.16.0.0/12`) || ClientIP(`192.168.0.0/16`)"
+        - traefik.tcp.routers.${SWARM_STACK_NAME}_postgresRoute.rule=ClientIP(`195.176.8.0/24`) || ClientIP(`10.0.0.0/8`) || ClientIP(`172.16.0.0/12`) || ClientIP(`192.168.0.0/16`)
   clusters-keeper:
     deploy:
       replicas: 0

--- a/services/traefik/docker-compose.local.yml
+++ b/services/traefik/docker-compose.local.yml
@@ -32,7 +32,7 @@ services:
       - "--entryPoints.https.transport.respondingTimeouts.idleTimeout=21600s" #6h, for https://github.com/traefik/traefik/issues/10805
       - "--entryPoints.https.transport.respondingTimeouts.writeTimeout=21600s" #6h, for https://github.com/traefik/traefik/issues/10805
       - "--entryPoints.https.transport.respondingTimeouts.readTimeout=21600s" #6h, for https://github.com/traefik/traefik/issues/10805
-      - "--entryPoints.master_postgres.address=:5432"
+      - "--entryPoints.postgres.address=:5432"
       - "--entrypoints.http.http.redirections.entrypoint.to=https"
       - "--entrypoints.http.http.redirections.entrypoint.scheme=https"
       - "--entrypoints.http.http.redirections.entrypoint.permanent=true"


### PR DESCRIPTION
## What do these changes do?
* remove wrong duplicates
* use proper entrypoint names

## Related issue/s

## Related PR/s
* fixes https://github.com/ITISFoundation/osparc-ops-environments/pull/976

## Checklist
- [ ] I tested and it works

<!--  Extra checks based on use case -->

<!-- New Stack Introduction
- [ ] The Stack has been included in CI Workflow
-->

<!-- New Service Introduction
- [ ] Service has resource limits and reservations
- [ ] Service has placement constraints or is global
- [ ] Service is restartable
- [ ] Service restart is zero-downtime
- [ ] Service is not bound to one specific node (e.g. via files or volumes)
- [ ] Relevant OPS E2E Test are added
- [ ] Service's Public URL is included in maintenance mode -->
