### PR TITLE
Registry: run on OPS nodes

### DIFF
--- a/services/registry/docker-compose.yml.j2
+++ b/services/registry/docker-compose.yml.j2
@@ -38,7 +38,7 @@ services:
       replicas: ${OPS_REGISTRY_REPLICAS}
       placement:
         constraints:
-          - node.labels.io.simcore.autoscaled-node!=true
+          - node.labels.ops==true
       resources:
         limits:
           memory: 1G


### PR DESCRIPTION
## What do these changes do?
Run registry on OPS nodes. It substitutes old out-of-date constraints

## Related issue/s
* https://github.com/ITISFoundation/osparc-ops-environments/issues/995

## Related PR/s

## Checklist
- [X] I tested and it works

<!--  Extra checks based on use case -->

<!-- New Stack Introduction
- [ ] The Stack has been included in CI Workflow
-->

<!-- New Service Introduction
- [ ] Service has resource limits and reservations
- [ ] Service has placement constraints or is global
- [ ] Service is restartable
- [ ] Service restart is zero-downtime
- [ ] Service is monitored (via prometheus and grafana)
- [ ] Service is not bound to one specific node (e.g. via files or volumes)
- [ ] Relevant OPS E2E Test are added
- [ ] Service's Public URL is included in maintenance mode
- [ ] Service's Public URL is included in testing mode -->
