### PR TITLE
[simcore] add storage replicas

### DIFF
--- a/services/simcore/docker-compose.yml
+++ b/services/simcore/docker-compose.yml
@@ -344,6 +344,7 @@ services:
     networks:
       - monitored
     deploy:
+      replicas: ${SIMCORE_STORAGE_REPLICAS}
       labels:
         # internal traefik
         - traefik.enable=true


### PR DESCRIPTION
## What do these changes do?
Since storage can be replicated, we make number of its replicas configurable via ENV

## Related issue/s
* https://github.com/ITISFoundation/osparc-simcore/issues/5621

## Related PR/s
* https://github.com/ITISFoundation/osparc-simcore/pull/7375
* https://git.speag.com/oSparc/osparc-ops-deployment-configuration/-/merge_requests/1345

## Checklist
- [ ] I tested and it works

<!--  Extra checks based on use case -->

<!-- New Stack Introduction
- [ ] The Stack has been included in CI Workflow
-->

<!-- New Service Introduction
- [ ] Service has resource limits and reservations
- [ ] Service has placement constraints or is global
- [ ] Service is restartable
- [ ] Service restart is zero-downtime
- [ ] Service is monitored (via prometheus and grafana)
- [ ] Service is not bound to one specific node (e.g. via files or volumes)
- [ ] Relevant OPS E2E Test are added
- [ ] Service's Public URL is included in maintenance mode
- [ ] Service's Public URL is included in testing mode -->
