### PR TITLE
Remove override storage replicas for master

### DIFF
--- a/services/simcore/docker-compose.deploy.master.yml
+++ b/services/simcore/docker-compose.deploy.master.yml
@@ -79,7 +79,3 @@ services:
   wb-api-server:
     deploy:
       replicas: 3
-
-  storage:
-    deploy:
-      replicas: 1


### PR DESCRIPTION
## What do these changes do?
We control storage replicas via env. We do not need to override replicas for master anymore

## Related issue/s

## Related PR/s
* https://github.com/ITISFoundation/osparc-ops-environments/pull/1000
* https://github.com/ITISFoundation/osparc-simcore/pull/7375

## Checklist
- [ ] I tested and it works

<!--  Extra checks based on use case -->

<!-- New Stack Introduction
- [ ] The Stack has been included in CI Workflow
-->

<!-- New Service Introduction
- [ ] Service has resource limits and reservations
- [ ] Service has placement constraints or is global
- [ ] Service is restartable
- [ ] Service restart is zero-downtime
- [ ] Service is monitored (via prometheus and grafana)
- [ ] Service is not bound to one specific node (e.g. via files or volumes)
- [ ] Relevant OPS E2E Test are added
- [ ] Service's Public URL is included in maintenance mode
- [ ] Service's Public URL is included in testing mode -->
