### PR TITLE
Add sto-worker simcore service

### DIFF
--- a/services/simcore/docker-compose.yml
+++ b/services/simcore/docker-compose.yml
@@ -376,6 +376,27 @@ services:
           cpus: "1"
           memory: "3G"
 
+  sto-worker:
+    networks:
+      - monitored
+    deploy:
+      replicas: ${SIMCORE_STO_WORKER_REPLICAS}
+      update_config:
+        parallelism: 2
+        order: start-first
+        failure_action: continue
+        delay: 10s
+      placement:
+        constraints:
+          - node.labels.simcore==true
+      resources:
+        reservations:
+          cpus: "1"
+          memory: "350M"
+        limits:
+          cpus: "2"
+          memory: "700M"
+
   director:
     # Certificate necessary for local deploiement only
     #secrets:


### PR DESCRIPTION
## What do these changes do?

## Related issue/s

## Related PR/s
* https://github.com/ITISFoundation/osparc-simcore/pull/7214

## Checklist
- [ ] I tested and it works

<!--  Extra checks based on use case -->

<!-- New Stack Introduction
- [ ] The Stack has been included in CI Workflow
-->

New Service Introduction
- [ ] Service has resource limits and reservations
- [ ] Service has placement constraints or is global
- [ ] Service is restartable
- [ ] Service restart is zero-downtime
- [ ] Service is monitored (via prometheus and grafana)
- [ ] Service is not bound to one specific node (e.g. via files or volumes)
- [ ] Relevant OPS E2E Test are added --> no applicable
- [ ] Service's Public URL is included in maintenance mode --> no applicable
- [ ] Service's Public URL is included in testing mode --> no applicable
