### PR TITLE
prepare simcore stack: keep secret path processing

### DIFF
--- a/scripts/deployments/prepare_simcore_stack.bash
+++ b/scripts/deployments/prepare_simcore_stack.bash
@@ -45,5 +45,20 @@ cd "$repo_basedir"
 log_info "Creating stack.yml file..."
 scripts/deployments/compose_stack_yml.bash
 
+log_info "Ensuring dask secrets are relative to the stack file"
+# Check if the dask_tls_cert secret exists and update its file path if it does.
+if ./yq eval '.secrets.dask_tls_cert' stack.yml >/dev/null; then
+    ./yq eval --inplace '.secrets.dask_tls_cert.file = "./assets/dask-certificates/dask-cert.pem"' stack.yml
+else
+    log_warning "The 'dask_tls_cert' secret does not exist. Skipping this step."
+fi
+
+# Check if the dask_tls_key secret exists and update its file path if it does.
+if ./yq eval '.secrets.dask_tls_key' stack.yml >/dev/null; then
+    ./yq eval --inplace '.secrets.dask_tls_key.file = "./assets/dask-certificates/dask-key.pem"' stack.yml
+else
+    log_warning "The 'dask_tls_key' secret does not exist. Skipping this step."
+fi
+
 log_info "Adding prefix $PREFIX_STACK_NAME to all services..."
 ./yq "with(.services; with_entries(.key |= \"${PREFIX_STACK_NAME}_\" + .))" stack.yml >"$this_script_dir"/stack_with_prefix.yml


### PR DESCRIPTION
## What do these changes do?

In #1015 secret path processing was removed what led to a bug (stack.yml file contains absolute paths to secrets which do not exist in deploy_simcore stage)

## Related issue/s

## Related PR/s
* https://github.com/ITISFoundation/osparc-ops-environments/pull/1015

## Checklist
- [x] I tested and it works

<!--  Extra checks based on use case -->

<!-- New Stack Introduction
- [ ] The Stack has been included in CI Workflow
-->

<!-- New Service Introduction
- [ ] Service has resource limits and reservations
- [ ] Service has placement constraints or is global
- [ ] Service is restartable
- [ ] Service restart is zero-downtime
- [ ] Service is monitored (via prometheus and grafana)
- [ ] Service is not bound to one specific node (e.g. via files or volumes)
- [ ] Relevant OPS E2E Test are added
- [ ] Service's Public URL is included in maintenance mode
- [ ] Service's Public URL is included in testing mode -->
