### PR TITLE
Add sto-worker-cpu-bound service

### DIFF
--- a/services/simcore/docker-compose.yml.j2
+++ b/services/simcore/docker-compose.yml.j2
@@ -382,9 +382,9 @@ services:
     deploy:
       replicas: ${SIMCORE_STO_WORKER_REPLICAS}
       update_config:
-        parallelism: 2
+        parallelism: 1
         order: start-first
-        failure_action: continue
+        failure_action: rollback
         delay: 10s
       placement:
         constraints:
@@ -396,6 +396,27 @@ services:
         limits:
           cpus: "1"
           memory: "700M"
+
+  sto-worker-cpu-bound:
+    networks:
+      - monitored
+    deploy:
+      replicas: ${SIMCORE_STO_WORKER_CPU_BOUND_REPLICAS}
+      update_config:
+        parallelism: 1
+        order: start-first
+        failure_action: rollback
+        delay: 10s
+      placement:
+        constraints:
+          - node.labels.simcore==true
+      resources:
+        reservations:
+          cpus: "0.1"
+          memory: "200M"
+        limits:
+          cpus: "1"
+          memory: "500M"
 
   director:
     # Certificate necessary for local deploiement only

--- a/services/simcore/docker-compose.yml.j2
+++ b/services/simcore/docker-compose.yml.j2
@@ -416,7 +416,7 @@ services:
           memory: "200M"
         limits:
           cpus: "1"
-          memory: "500M"
+          memory: "1G"
 
   director:
     # Certificate necessary for local deploiement only


### PR DESCRIPTION
## What do these changes do?

Load while downloading 2 files (MB)
![image](https://github.com/user-attachments/assets/b10ae8df-db6a-4e4c-b413-487fa702d76a)


## Related issue/s

## Related PR/s
* https://github.com/ITISFoundation/osparc-simcore/pull/7471
* https://git.speag.com/oSparc/osparc-ops-deployment-configuration/-/merge_requests/1362

## Checklist
- [ ] I tested and it works
- [x] Service has resource limits and reservations
- [x] Service has placement constraints or is global
- [x] Service is restartable
- [x] Service restart is zero-downtime
- [x] Service is monitored (via prometheus and grafana)
- [x] Service is not bound to one specific node (e.g. via files or volumes)
- [ ] ~~Relevant OPS E2E Test are added~~
- [ ] ~~Service's Public URL is included in maintenance mode~~
- [ ] ~~Service's Public URL is included in testing mode~~
