### PR TITLE
Add update portainer password help comment

### DIFF
--- a/services/portainer/Makefile
+++ b/services/portainer/Makefile
@@ -95,6 +95,7 @@ ${TEMP_COMPOSE}-aws: docker-compose.yml docker-compose.aws.yml .env
 secrets: .env ## Construct secrets for portainer pwd, to change pwd it need to be done manually https://git.speag.com/oSparc/osparc-ops-deployment-configuration/-/wikis/Update-Portainer-Password
 	@if [ -z $(IS_PORTAINER_SERVICE_RUNNING) ]; then\
 		echo "Setting portainer_admin_password (can only set but not update password!)" \
+		&& echo "To update password follow https://portal.portainer.io/knowledge/how-do-i-reset-my-portainer-password" \
 		&& docker secret rm portainer_admin_password 2>/dev/null; \
 		set -o allexport; source .env; set +o allexport; \
 		echo -n "$${PORTAINER_ADMIN_PWD}" | docker secret create portainer_admin_password -  2>/dev/null; \


### PR DESCRIPTION
## What do these changes do?

## Related issue/s
* https://github.com/ITISFoundation/osparc-ops-environments/issues/984
  - This issue triggered our review of portainer secrets. Rolling secret update does not make sense in this case since portainer is not capable of updating password automatically. It requires manual actions described in the comment added in this PR
## Related PR/s

## Checklist
- [X] I tested and it works

<!--  Extra checks based on use case -->

<!-- New Stack Introduction
- [ ] The Stack has been included in CI Workflow
-->

<!-- New Service Introduction
- [ ] Service has resource limits and reservations
- [ ] Service has placement constraints or is global
- [ ] Service is restartable
- [ ] Service restart is zero-downtime
- [ ] Service is monitored (via prometheus and grafana)
- [ ] Service is not bound to one specific node (e.g. via files or volumes)
- [ ] Relevant OPS E2E Test are added
- [ ] Service's Public URL is included in maintenance mode
- [ ] Service's Public URL is included in testing mode -->
