### PR TITLE
Fix traefik www capture router

### DIFF
--- a/services/traefik/docker-compose.yml.j2
+++ b/services/traefik/docker-compose.yml.j2
@@ -105,7 +105,8 @@ services:
         # via https://community.traefik.io/t/v2-2-8-global-redirect-www-to-non-www-with-http-to-https/7428
         # see also: https://community.traefik.io/t/get-a-valid-ssl-certificate-for-www-domains-via-traefik-and-lets-encrypt/2023
         # Global redirection: https (www.) to https
-        - traefik.http.routers.www-catchall.rule={{ DEPLOYMENT_FQDNS_WWW_CAPTURE_TRAEFIK_RULE.strip("\"") }}
+        # why .strip("\"'") ? --> https://github.com/kolypto/j2cli/issues/77
+        - traefik.http.routers.www-catchall.rule={{ DEPLOYMENT_FQDNS_WWW_CAPTURE_TRAEFIK_RULE.strip("\"'") }}
         - traefik.http.routers.www-catchall.priority=100000
         - traefik.http.routers.www-catchall.entrypoints=https,http
         - traefik.http.routers.www-catchall.tls=true


### PR DESCRIPTION
Strip `'` around router's value (e.g. use `.rule=Host(...)` instead of **wrong** `.rule='Host(...)'`. Surrounding `'` are invalid syntax for traefik 

j2cli that we use preserves quotes around variable value being substituted https://github.com/kolypto/j2cli/issues/77. This leads to a wrong label syntax (e.g. label="asda" instead of label=asda)

![image](https://github.com/user-attachments/assets/5024201f-77e8-4be8-9a20-b146ccb10f57)

## What do these changes do?

## Related issue/s
* https://github.com/ITISFoundation/osparc-ops-environments/issues/1028

## Related PR/s
* https://github.com/ITISFoundation/osparc-ops-environments/pull/1013

## Checklist
- [x] I tested and it works

<!--  Extra checks based on use case -->

<!-- New Stack Introduction
- [ ] The Stack has been included in CI Workflow
-->

<!-- New Service Introduction
- [ ] Service has resource limits and reservations
- [ ] Service has placement constraints or is global
- [ ] Service is restartable
- [ ] Service restart is zero-downtime
- [ ] Service is monitored (via prometheus and grafana)
- [ ] Service is not bound to one specific node (e.g. via files or volumes)
- [ ] Relevant OPS E2E Test are added
- [ ] Service's Public URL is included in maintenance mode
- [ ] Service's Public URL is included in testing mode -->
