### PR TITLE
[AWS] Expose rabbit for private subnets

### DIFF
--- a/services/simcore/docker-compose.deploy.aws.yml
+++ b/services/simcore/docker-compose.deploy.aws.yml
@@ -3,7 +3,6 @@ services:
     volumes:
       - /docker/volumes/:/docker/volumes/
 
-
   dask-sidecar:
     deploy:
       placement:
@@ -24,6 +23,7 @@ services:
   postgres:
     deploy:
       replicas: 0
+
   traefik:
     command:
       - "--api=true"
@@ -52,7 +52,7 @@ services:
       - "--entryPoints.traefik_monitor.address=:8080"
       - "--entryPoints.traefik_monitor.forwardedHeaders.insecure"
       - "--providers.swarm.endpoint=unix:///var/run/docker.sock"
-      - "--providers.swarm.network=${SWARM_STACK_NAME}_default"      # https://github.com/traefik/traefik/issues/7886
+      - "--providers.swarm.network=${SWARM_STACK_NAME}_default" # https://github.com/traefik/traefik/issues/7886
       - "--providers.swarm.refreshSeconds=1"
       - "--providers.swarm.exposedByDefault=false"
       - "--providers.swarm.constraints=Label(`io.simcore.zone`, `${TRAEFIK_SIMCORE_ZONE}`)"
@@ -73,9 +73,17 @@ services:
     deploy:
       replicas: 3
 
+  rabbit:
+    deploy:
+      labels:
+        - traefik.tcp.services.rabbit.loadBalancer.server.port=5672
+        - traefik.tcp.routers.rabbit.entrypoints=rabbit
+        - traefik.tcp.routers.rabbit.tls=false
+        - traefik.tcp.routers.rabbit.rule=ClientIP(`10.0.0.0/8`) || ClientIP(`172.16.0.0/12`) || ClientIP(`192.168.0.0/16`)
+
 volumes:
-   efs_volume:
-       driver_opts:
-           type: nfs
-           o: addr=${EFS_DNS_NAME},rw,nfsvers=4.1,rsize=1048576,wsize=1048576,hard,timeo=600,retrans=2,noresvport
-           device: :/
+  efs_volume:
+    driver_opts:
+      type: nfs
+      o: addr=${EFS_DNS_NAME},rw,nfsvers=4.1,rsize=1048576,wsize=1048576,hard,timeo=600,retrans=2,noresvport
+      device: :/

--- a/services/simcore/docker-compose.yml.j2
+++ b/services/simcore/docker-compose.yml.j2
@@ -631,13 +631,13 @@ services:
       labels:
         - traefik.enable=true
         - traefik.docker.network=${PUBLIC_NETWORK}
-        - traefik.http.services.${PREFIX_STACK_NAME}_rabbit.loadbalancer.server.port=15672
-        - traefik.http.routers.${PREFIX_STACK_NAME}_rabbit.rule=Host(`${MONITORING_DOMAIN}`) && PathPrefix(`/${PREFIX_STACK_NAME}_rabbit`)
-        - traefik.http.routers.${PREFIX_STACK_NAME}_rabbit.entrypoints=https
-        - traefik.http.routers.${PREFIX_STACK_NAME}_rabbit.tls=true
-        - traefik.http.middlewares.${PREFIX_STACK_NAME}_rabbit_replace_regex.replacepathregex.regex=^/${PREFIX_STACK_NAME}_rabbit/(.*)$$
-        - traefik.http.middlewares.${PREFIX_STACK_NAME}_rabbit_replace_regex.replacepathregex.replacement=/$${1}
-        - traefik.http.routers.${PREFIX_STACK_NAME}_rabbit.middlewares=${PREFIX_STACK_NAME}_rabbit_replace_regex@swarm, ops_gzip@swarm
+        - traefik.http.services.${PREFIX_STACK_NAME}_rabbit_console.loadbalancer.server.port=15672
+        - traefik.http.routers.${PREFIX_STACK_NAME}_rabbit_console.rule=Host(`${MONITORING_DOMAIN}`) && PathPrefix(`/${PREFIX_STACK_NAME}_rabbit`)
+        - traefik.http.routers.${PREFIX_STACK_NAME}_rabbit_console.entrypoints=https
+        - traefik.http.routers.${PREFIX_STACK_NAME}_rabbit_console.tls=true
+        - traefik.http.middlewares.${PREFIX_STACK_NAME}_rabbit_console_replace_regex.replacepathregex.regex=^/${PREFIX_STACK_NAME}_rabbit/(.*)$$
+        - traefik.http.middlewares.${PREFIX_STACK_NAME}_rabbit_console_replace_regex.replacepathregex.replacement=/$${1}
+        - traefik.http.routers.${PREFIX_STACK_NAME}_rabbit_console.middlewares=${PREFIX_STACK_NAME}_rabbit_console_replace_regex@swarm, ops_gzip@swarm
       update_config:
         parallelism: 2
         order: start-first

--- a/services/traefik/docker-compose.aws.yml
+++ b/services/traefik/docker-compose.aws.yml
@@ -23,6 +23,7 @@ services:
       - "--entryPoints.https.transport.respondingTimeouts.writeTimeout=21600s" #6h, for https://github.com/traefik/traefik/issues/10805
       - "--entryPoints.https.transport.respondingTimeouts.readTimeout=21600s" #6h, for https://github.com/traefik/traefik/issues/10805
       - "--entryPoints.smtp.address=:25"
+      - "--entryPoints.rabbit.address=:5672"
       - "--providers.swarm.endpoint=unix:///var/run/docker.sock"
       - "--providers.swarm.exposedByDefault=false"
       - "--core.defaultRuleSyntax=v2"
@@ -34,6 +35,10 @@ services:
       - "--entryPoints.https.forwardedHeaders.insecure"
       - "--providers.file.directory=/etc/traefik/"
       - "--providers.file.watch=true"
+    ports:
+      - target: 5672
+        published: 5672
+        mode: host
     environment:
       - AWS_ACCESS_KEY_ID=${ROUTE53_DNS_CHALLANGE_ACCESS_KEY}
       - AWS_SECRET_ACCESS_KEY=${ROUTE53_DNS_CHALLANGE_SECRET_KEY}


### PR DESCRIPTION
Since computational clusters run outside docker swarm cluster on AWS Deployments but still need to access RabbitMQ, we need to make it available on private subnets (within VPC). This does not mean public access since manager nodes are private on AWS Deployments.

Bonus:
* Rename route to management console (add `console` suffix)

FYI: @sanderegg 

## What do these changes do?

## Related issue/s
* https://github.com/ITISFoundation/osparc-ops-environments/issues/1030

## Related PR/s

## Checklist
- [x] I tested and it works

<!--  Extra checks based on use case -->

<!-- New Stack Introduction
- [ ] The Stack has been included in CI Workflow
-->

<!-- New Service Introduction
- [ ] Service has resource limits and reservations
- [ ] Service has placement constraints or is global
- [ ] Service is restartable
- [ ] Service restart is zero-downtime
- [ ] Service is monitored (via prometheus and grafana)
- [ ] Service is not bound to one specific node (e.g. via files or volumes)
- [ ] Relevant OPS E2E Test are added
- [ ] Service's Public URL is included in maintenance mode
- [ ] Service's Public URL is included in testing mode -->
