### PR TITLE
Expose dynamic scheduler API

### DIFF
--- a/services/simcore/docker-compose.yml.j2
+++ b/services/simcore/docker-compose.yml.j2
@@ -931,13 +931,22 @@ services:
       labels:
         - traefik.enable=true
         - traefik.docker.network=${PUBLIC_NETWORK}
+        # dynamic-scheduler service
         - traefik.http.services.${PREFIX_STACK_NAME}_dynamic_scheduler.loadbalancer.server.port=8000
         - traefik.http.services.${PREFIX_STACK_NAME}_dynamic_scheduler.loadbalancer.sticky.cookie=true
         - traefik.http.services.${PREFIX_STACK_NAME}_dynamic_scheduler.loadbalancer.sticky.cookie.name=sticky_session
+        # dynamic-scheduler GUI Router
         - traefik.http.routers.${PREFIX_STACK_NAME}_dynamic_scheduler.rule=Host(`${MONITORING_DOMAIN}`) && PathPrefix(`/dynamic-scheduler`)
         - traefik.http.routers.${PREFIX_STACK_NAME}_dynamic_scheduler.entrypoints=https
         - traefik.http.routers.${PREFIX_STACK_NAME}_dynamic_scheduler.tls=true
         - traefik.http.routers.${PREFIX_STACK_NAME}_dynamic_scheduler.middlewares=ops_gzip@swarm, ops_auth@swarm
+        # dynamic-scheduler API Router
+        - traefik.http.routers.${PREFIX_STACK_NAME}_dynamic_scheduler_api.rule=Host(`${MONITORING_DOMAIN}`) && PathPrefix(`/dynamic-scheduler/v1`)
+        - traefik.http.routers.${PREFIX_STACK_NAME}_dynamic_scheduler_api.entrypoints=https
+        - traefik.http.routers.${PREFIX_STACK_NAME}_dynamic_scheduler_api.tls=true
+        - traefik.http.middlewares.dynamic_scheduler_api_replace_regex.replacepathregex.regex=^/dynamic-scheduler/v1(.*)$$
+        - traefik.http.middlewares.dynamic_scheduler_api_replace_regex.replacepathregex.replacement=/v1$${1}
+        - traefik.http.routers.${PREFIX_STACK_NAME}_dynamic_scheduler_api.middlewares=ops_gzip@swarm, ops_auth@swarm, dynamic_scheduler_api_replace_regex
 
   notifications:
     networks:


### PR DESCRIPTION
API is exposed under `/v1` path. Here we build traefik Router to point traffic to this endpoint

## What do these changes do?
* https://github.com/ITISFoundation/osparc-simcore/pull/7454

## Related issue/s
* https://github.com/ITISFoundation/osparc-ops-environments/issues/944
## Related PR/s

## Checklist
- [x] I tested and it works

<!--  Extra checks based on use case -->

<!-- New Stack Introduction
- [ ] The Stack has been included in CI Workflow
-->

<!-- New Service Introduction
- [ ] Service has resource limits and reservations
- [ ] Service has placement constraints or is global
- [ ] Service is restartable
- [ ] Service restart is zero-downtime
- [ ] Service is monitored (via prometheus and grafana)
- [ ] Service is not bound to one specific node (e.g. via files or volumes)
- [ ] Relevant OPS E2E Test are added
- [ ] Service's Public URL is included in maintenance mode
- [ ] Service's Public URL is included in testing mode -->
