### PR TITLE
Prometheus enable exemplars and tracing

### DIFF
--- a/services/monitoring/docker-compose.master.yml.j2
+++ b/services/monitoring/docker-compose.master.yml.j2
@@ -6,6 +6,16 @@ services:
         constraints:
           - node.labels.grafana==true
   prometheuscatchall:
+    command:
+      - "--config.file=/etc/prometheus/prometheus.yml"
+      - "--storage.tsdb.path=/prometheus"
+      - "--storage.tsdb.retention=${MONITORING_PROMETHEUS_RETENTION}"
+      - "--web.console.libraries=/usr/share/prometheus/console_libraries"
+      - "--web.console.templates=/usr/share/prometheus/consoles"
+      - "--web.external-url=https://${MONITORING_DOMAIN}/prometheus/"
+      - "--web.route-prefix=/"
+      - "--storage.tsdb.allow-overlapping-blocks" # via https://jessicagreben.medium.com/prometheus-fill-in-data-for-new-recording-rules-30a14ccb8467
+      - "--enable-feature=exemplar-storage"
     deploy:
       placement:
         constraints:

--- a/services/monitoring/docker-compose.master.yml.j2
+++ b/services/monitoring/docker-compose.master.yml.j2
@@ -6,16 +6,6 @@ services:
         constraints:
           - node.labels.grafana==true
   prometheuscatchall:
-    command:
-      - "--config.file=/etc/prometheus/prometheus.yml"
-      - "--storage.tsdb.path=/prometheus"
-      - "--storage.tsdb.retention=${MONITORING_PROMETHEUS_RETENTION}"
-      - "--web.console.libraries=/usr/share/prometheus/console_libraries"
-      - "--web.console.templates=/usr/share/prometheus/consoles"
-      - "--web.external-url=https://${MONITORING_DOMAIN}/prometheus/"
-      - "--web.route-prefix=/"
-      - "--storage.tsdb.allow-overlapping-blocks" # via https://jessicagreben.medium.com/prometheus-fill-in-data-for-new-recording-rules-30a14ccb8467
-      - "--enable-feature=exemplar-storage"
     deploy:
       placement:
         constraints:

--- a/services/monitoring/docker-compose.yml.j2
+++ b/services/monitoring/docker-compose.yml.j2
@@ -44,6 +44,7 @@ services:
       - "--web.external-url=https://${MONITORING_DOMAIN}/prometheus/"
       - "--web.route-prefix=/"
       - "--storage.tsdb.allow-overlapping-blocks" # via https://jessicagreben.medium.com/prometheus-fill-in-data-for-new-recording-rules-30a14ccb8467
+      - "--enable-feature=exemplar-storage"
       #- "--web.enable-admin-api" This allows messing with prometheus using its API from the CLI. Disabled for security reasons by default.
     networks:
       - monitored

--- a/services/monitoring/grafana/terraform/datasources.tf
+++ b/services/monitoring/grafana/terraform/datasources.tf
@@ -14,6 +14,16 @@ resource "grafana_data_source" "prometheuscatchall" {
   basic_auth_enabled = false
   is_default         = false
   uid                = "RmZEr52nz"
+
+  json_data_encoded = jsonencode({
+    exemplarTraceIdDestinations = [
+      {
+        datasourceUid = "tempo"
+        name          = "TraceID"
+      }
+    ]
+  })
+
 }
 
 resource "grafana_data_source" "tempo" {


### PR DESCRIPTION
## What do these changes do?
Enable [exemplars feature](https://prometheus.io/docs/prometheus/latest/feature_flags/#exemplars-storage) and configure prometheus to work with traces and tempo


## Related issue/s

## Related PR/s
* https://github.com/ITISFoundation/osparc-simcore/pull/7644
* https://git.speag.com/oSparc/osparc-ops-deployment-configuration/-/merge_requests/1405

## Checklist
- [x] I tested and it works

<!--  Extra checks based on use case -->

<!-- New Stack Introduction
- [ ] The Stack has been included in CI Workflow
-->

<!-- New Service Introduction
- [ ] Service has resource limits and reservations
- [ ] Service has placement constraints or is global
- [ ] Service is restartable
- [ ] Service restart is zero-downtime
- [ ] Service is monitored (via prometheus and grafana)
- [ ] Service is not bound to one specific node (e.g. via files or volumes)
- [ ] Relevant OPS E2E Test are added
- [ ] Service's Public URL is included in maintenance mode
- [ ] Service's Public URL is included in testing mode -->
