### PR TITLE
traefik v3.4 deprecated `traefik.docker.` in favor of `traefik.swarm.` labels

### DIFF
--- a/services/admin-panels/docker-compose.yml.j2
+++ b/services/admin-panels/docker-compose.yml.j2
@@ -87,7 +87,7 @@ services:
     deploy:
       labels:
         - traefik.enable=true
-        - traefik.docker.network=${PUBLIC_NETWORK}
+        - traefik.swarm.network=${PUBLIC_NETWORK}
         - traefik.http.services.adminpanels.loadbalancer.server.port=8888
         - traefik.http.routers.adminpanels.rule=Host(`${ADMINPANELS_DOMAIN}`)
         - traefik.http.routers.adminpanels.entrypoints=https

--- a/services/appmotion_gateway/docker-compose.yml.j2
+++ b/services/appmotion_gateway/docker-compose.yml.j2
@@ -13,7 +13,7 @@ services:
             replicas: 0
             labels:
                 - traefik.enable=true
-                - traefik.docker.network=${PUBLIC_NETWORK}
+                - traefik.swarm.network=${PUBLIC_NETWORK}
                 - traefik.http.services.adminer_appmotion_gateway.loadbalancer.server.port=8080
                 - traefik.http.routers.adminer_appmotion_gateway.rule=Host(`${MONITORING_DOMAIN}`) && PathPrefix(`/adminer/appmotion_gateway`)
                 - traefik.http.routers.adminer_appmotion_gateway.entrypoints=https
@@ -75,7 +75,7 @@ services:
             replicas: 1
             labels:
                 - traefik.enable=true
-                - traefik.docker.network=${PUBLIC_NETWORK}
+                - traefik.swarm.network=${PUBLIC_NETWORK}
                 - traefik.http.routers.appmotion_gateway.rule=${DEPLOYMENT_FQDNS_APPMOTION_CAPTURE_TRAEFIK_RULE}
                 - traefik.http.routers.appmotion_gateway.entrypoints=https
                 - traefik.http.routers.appmotion_gateway.tls=true

--- a/services/filestash/docker-compose.yml.j2
+++ b/services/filestash/docker-compose.yml.j2
@@ -13,7 +13,7 @@ services:
     deploy:
       labels:
         - traefik.enable=true
-        - traefik.docker.network=${PUBLIC_NETWORK}
+        - traefik.swarm.network=${PUBLIC_NETWORK}
         - traefik.http.services.filestash.loadbalancer.server.port=8334
         - traefik.http.routers.filestash.rule=Host(`${FILESTASH_DOMAIN}`)
         - traefik.http.routers.filestash.entrypoints=https

--- a/services/graylog/docker-compose.yml.j2
+++ b/services/graylog/docker-compose.yml.j2
@@ -88,7 +88,7 @@ services:
 
       labels:
         - traefik.enable=true
-        - traefik.docker.network=${PUBLIC_NETWORK}
+        - traefik.swarm.network=${PUBLIC_NETWORK}
         # direct access through port
         - traefik.http.services.graylog.loadbalancer.server.port=9000
         - traefik.http.routers.graylog.rule=Host(`${MONITORING_DOMAIN}`) && PathPrefix(`/graylog`)

--- a/services/jaeger/docker-compose.yml.j2
+++ b/services/jaeger/docker-compose.yml.j2
@@ -17,7 +17,7 @@ services:
           - node.labels.ops==true
       labels:
         - traefik.enable=true
-        - traefik.docker.network=${PUBLIC_NETWORK}
+        - traefik.swarm.network=${PUBLIC_NETWORK}
         - traefik.http.services.jaeger.loadbalancer.server.port=16686
         - traefik.http.routers.jaeger.rule=Host(`${MONITORING_DOMAIN}`) && PathPrefix(`/jaeger`)
         - traefik.http.routers.jaeger.entrypoints=https

--- a/services/maintenance-page/docker-compose.yml.j2
+++ b/services/maintenance-page/docker-compose.yml.j2
@@ -26,7 +26,7 @@ services:
           - node.labels.ops==true
       labels:
         - traefik.enable=true
-        - traefik.docker.network=${PUBLIC_NETWORK}
+        - traefik.swarm.network=${PUBLIC_NETWORK}
         - traefik.http.routers.{{"maintenance_" + j2item.replace('@','').replace(' ','').replace('.','').replace('-','').replace('\'','') + "_html"}}.priority={{MAINTENANCE_PAGES_TRAEFIK_PRIORITY}}
         - traefik.http.routers.{{"maintenance_" + j2item.replace('@','').replace(' ','').replace('.','').replace('-','').replace('\'','') + "_html"}}.rule=Host(`{{VENDOR_MANUAL_SUBDOMAIN_PREFIX}}.{{j2item}}`) || (Host(`{{j2item}}`) && PathPrefix(`/`)) || (HostRegexp(`services.{{j2item}}`,`{subhost:[a-zA-Z0-9-]+}.services.{{j2item}}`) && PathPrefix(`/`))
         - traefik.http.routers.{{"maintenance_" + j2item.replace('@','').replace(' ','').replace('.','').replace('-','').replace('\'','') + "_html"}}.tls=true
@@ -50,7 +50,7 @@ services:
           - node.labels.ops==true
       labels:
           - traefik.enable=true
-          - traefik.docker.network=${PUBLIC_NETWORK}
+          - traefik.swarm.network=${PUBLIC_NETWORK}
           - traefik.http.routers.nginx_api.priority={{MAINTENANCE_PAGES_TRAEFIK_PRIORITY}}
           - traefik.http.routers.nginx_api.tls=true
           - traefik.http.routers.nginx_api.rule=${DEPLOYMENT_API_DOMAIN_CAPTURE_TRAEFIK_RULE}

--- a/services/minio/docker-compose.yaml
+++ b/services/minio/docker-compose.yaml
@@ -22,7 +22,7 @@ services:
         window: 60s
       labels:
         - traefik.enable=true
-        - traefik.docker.network=${PUBLIC_NETWORK}
+        - traefik.swarm.network=${PUBLIC_NETWORK}
         # direct access without path (necessary for minio client it does not like /path)
         - traefik.http.services.minio9000.loadbalancer.server.port=9000
         - traefik.http.services.minio9000.loadbalancer.healthcheck.path=/minio/health/ready

--- a/services/monitoring/docker-compose.yml.j2
+++ b/services/monitoring/docker-compose.yml.j2
@@ -52,7 +52,7 @@ services:
     deploy:
       labels:
         - traefik.enable=true
-        - traefik.docker.network=${PUBLIC_NETWORK}
+        - traefik.swarm.network=${PUBLIC_NETWORK}
         # direct access through port
         - traefik.http.services.prometheuscatchall.loadbalancer.server.port=${MONITORING_PROMETHEUS_PORT}
         - traefik.http.routers.prometheuscatchall.rule=Host(`${MONITORING_DOMAIN}`) && PathPrefix(`/prometheus`)
@@ -98,7 +98,7 @@ services:
     deploy:
       labels:
         - traefik.enable=true
-        - traefik.docker.network=${PUBLIC_NETWORK}
+        - traefik.swarm.network=${PUBLIC_NETWORK}
         # direct access through port
         - traefik.http.services.prometheusfederation.loadbalancer.server.port=${MONITORING_PROMETHEUS_PORT}
         - traefik.http.routers.prometheusfederation.rule=Host(`${MONITORING_DOMAIN}`) && PathPrefix(`/prometheusfederation`)
@@ -232,7 +232,7 @@ services:
       #  condition: on-failure
       labels:
         - traefik.enable=true
-        - traefik.docker.network=${PUBLIC_NETWORK}
+        - traefik.swarm.network=${PUBLIC_NETWORK}
         # direct access through port
         - traefik.http.services.grafana.loadbalancer.server.port=3000
         - traefik.http.routers.grafana.rule=Host(`${MONITORING_DOMAIN}`) && PathPrefix(`/grafana`)
@@ -380,7 +380,7 @@ services:
     deploy:
       labels:
         - traefik.enable=true
-        - traefik.docker.network=${PUBLIC_NETWORK}
+        - traefik.swarm.network=${PUBLIC_NETWORK}
         - traefik.http.services.tempo.loadbalancer.server.port=9095
         - traefik.http.routers.tempo.rule=Host(`${MONITORING_DOMAIN}`) && PathPrefix(`/tempo`)
         - traefik.http.routers.tempo.priority=10

--- a/services/redis-commander/docker-compose.yml.j2
+++ b/services/redis-commander/docker-compose.yml.j2
@@ -24,7 +24,7 @@ services:
           - node.labels.ops == true
       labels:
         - traefik.enable=true
-        - traefik.docker.network=${PUBLIC_NETWORK}
+        - traefik.swarm.network=${PUBLIC_NETWORK}
         - traefik.http.services.redis.loadbalancer.server.port=8081
         - traefik.http.routers.redis.rule=Host(`${MONITORING_DOMAIN}`) && PathPrefix(`/redis`)
         - traefik.http.routers.redis.entrypoints=https

--- a/services/registry/docker-compose.yml.j2
+++ b/services/registry/docker-compose.yml.j2
@@ -53,7 +53,7 @@ services:
           cpus: '0.1'
       labels:
         - traefik.enable=true
-        - traefik.docker.network=${PUBLIC_NETWORK}
+        - traefik.swarm.network=${PUBLIC_NETWORK}
         # direct access through port
         - traefik.http.services.registry.loadbalancer.server.port=5000
         - traefik.http.routers.registry.rule=Host(`${REGISTRY_DOMAIN}`)

--- a/services/simcore/docker-compose.yml.j2
+++ b/services/simcore/docker-compose.yml.j2
@@ -348,7 +348,7 @@ services:
       labels:
         # internal traefik
         - traefik.enable=true
-        - traefik.docker.network=${SWARM_STACK_NAME}_default
+        - traefik.swarm.network=${SWARM_STACK_NAME}_default
         - io.simcore.zone=${TRAEFIK_SIMCORE_ZONE}
         - traefik.http.routers.${SWARM_STACK_NAME}_storage.rule=${DEPLOYMENT_FQDNS_CAPTURE_STORAGE}
         - traefik.http.routers.${SWARM_STACK_NAME}_storage.entrypoints=http
@@ -538,7 +538,7 @@ services:
           - node.labels.simcore==true
       labels:
         - traefik.enable=true
-        - traefik.docker.network=${PUBLIC_NETWORK}
+        - traefik.swarm.network=${PUBLIC_NETWORK}
         - traefik.http.services.${PREFIX_STACK_NAME}_dask_scheduler.loadbalancer.server.port=8787
         - traefik.http.routers.${PREFIX_STACK_NAME}_dask_scheduler.rule=Host(`${MONITORING_DOMAIN}`) && PathPrefix(`/${PREFIX_STACK_NAME}_dask`)
         - traefik.http.routers.${PREFIX_STACK_NAME}_dask_scheduler.entrypoints=https
@@ -630,7 +630,7 @@ services:
       replicas: ${RABBIT_SELF_HOSTED_REPLICAS}
       labels:
         - traefik.enable=true
-        - traefik.docker.network=${PUBLIC_NETWORK}
+        - traefik.swarm.network=${PUBLIC_NETWORK}
         - traefik.http.services.${PREFIX_STACK_NAME}_rabbit_console.loadbalancer.server.port=15672
         - traefik.http.routers.${PREFIX_STACK_NAME}_rabbit_console.rule=Host(`${MONITORING_DOMAIN}`) && PathPrefix(`/${PREFIX_STACK_NAME}_rabbit`)
         - traefik.http.routers.${PREFIX_STACK_NAME}_rabbit_console.entrypoints=https
@@ -724,7 +724,7 @@ services:
       labels:
         - traefik.enable=true
         - io.simcore.zone=${TRAEFIK_SIMCORE_ZONE}
-        - traefik.docker.network=${PUBLIC_NETWORK}
+        - traefik.swarm.network=${PUBLIC_NETWORK}
         - traefik.tcp.services.${SWARM_STACK_NAME}_postgres.loadBalancer.server.port=5432
         - traefik.tcp.routers.postgres.service=${SWARM_STACK_NAME}_postgres
         - traefik.tcp.routers.postgres.entrypoints=postgres
@@ -763,7 +763,7 @@ services:
         - prometheus-port=8082
         # external traefik
         - traefik.enable=true
-        - traefik.docker.network=${PUBLIC_NETWORK}
+        - traefik.swarm.network=${PUBLIC_NETWORK}
         # oSparc web
         - traefik.http.services.${SWARM_STACK_NAME}_simcore_http.loadbalancer.server.port=80
         - traefik.http.routers.${SWARM_STACK_NAME}_simcore_http.entrypoints=https
@@ -930,7 +930,7 @@ services:
           cpus: '0.1'
       labels:
         - traefik.enable=true
-        - traefik.docker.network=${PUBLIC_NETWORK}
+        - traefik.swarm.network=${PUBLIC_NETWORK}
         # dynamic-scheduler service
         - traefik.http.services.${PREFIX_STACK_NAME}_dynamic_scheduler.loadbalancer.server.port=8000
         - traefik.http.services.${PREFIX_STACK_NAME}_dynamic_scheduler.loadbalancer.sticky.cookie=true

--- a/services/traefik/docker-compose.yml.j2
+++ b/services/traefik/docker-compose.yml.j2
@@ -82,7 +82,7 @@ services:
           - node.role == manager
       labels:
         - traefik.enable=true
-        - traefik.docker.network=${PUBLIC_NETWORK}
+        - traefik.swarm.network=${PUBLIC_NETWORK}
         # ssl header necessary so that socket.io upgrades correctly from polling to websocket mode. the middleware must be attached to the right connection.
         - traefik.http.middlewares.ops_sslheader.headers.customrequestheaders.X-Forwarded-Proto=https
         ####### SECURITY HEADERS --> See https://infosec.mozilla.org/guidelines/web_security
@@ -195,7 +195,7 @@ services:
           - node.labels.traefik==true
       labels:
         - traefik.enable=true
-        - traefik.docker.network=${PUBLIC_NETWORK}
+        - traefik.swarm.network=${PUBLIC_NETWORK}
         - traefik.http.services.whoami.loadbalancer.server.port=80
         - traefik.http.routers.whoami.rule=Host(`${MONITORING_DOMAIN}`) &&
           PathPrefix(`/whoami`)

--- a/services/vendors/docker-compose.yml.j2
+++ b/services/vendors/docker-compose.yml.j2
@@ -26,7 +26,7 @@ services:
         delay: 10s
       labels:
         - traefik.enable=true
-        - traefik.docker.network=${PUBLIC_NETWORK}
+        - traefik.swarm.network=${PUBLIC_NETWORK}
         - traefik.http.services.vendor_manual.loadbalancer.server.port=${VENDOR_MANUAL_PORT}
         - traefik.http.routers.vendor_manual.entrypoints=https
         - traefik.http.routers.vendor_manual.tls=true


### PR DESCRIPTION
## What do these changes do?
should fix zillions of `WRN Labels traefik.docker.* for Swarm provider are deprecated. Please use traefik.swarm.* labels instead` in traefik logs
## Related issue/s
- relates to https://github.com/ITISFoundation/private-issues/issues/79

Please @YuryHrytsuk @mrnicegyu11 can you double check that this does not go in staging or prod at the wrong time? shall I create multiple PRs? how does this one work?

## Related PR/s

## Checklist
- [ ] I tested and it works

<!--  Extra checks based on use case -->

<!-- New Stack Introduction
- [ ] The Stack has been included in CI Workflow
-->

<!-- New Service Introduction
- [ ] Service has resource limits and reservations
- [ ] Service has placement constraints or is global
- [ ] Service is restartable
- [ ] Service restart is zero-downtime
- [ ] Service is monitored (via prometheus and grafana)
- [ ] Service is not bound to one specific node (e.g. via files or volumes)
- [ ] Relevant OPS E2E Test are added
- [ ] Service's Public URL is included in maintenance mode
- [ ] Service's Public URL is included in testing mode -->
