### PR TITLE
Fix rabbit prometheus scrape config on master

### DIFF
--- a/services/monitoring/prometheus/prometheus-simcore.yml
+++ b/services/monitoring/prometheus/prometheus-simcore.yml
@@ -92,7 +92,7 @@ scrape_configs:
       - names:
           - "tasks.production_rabbit"
           - "tasks.staging_rabbit"
-          - "task.master_rabbit"
+          - "tasks.master_rabbit"
         type: "A"
         port: 15692
       - names:


### PR DESCRIPTION
## What do these changes do?

## Related issue/s
* https://github.com/ITISFoundation/osparc-ops-environments/issues/1048

## Related PR/s

## Checklist
- [ ] I tested and it works

<!--  Extra checks based on use case -->

<!-- New Stack Introduction
- [ ] The Stack has been included in CI Workflow
-->

<!-- New Service Introduction
- [ ] Service has resource limits and reservations
- [ ] Service has placement constraints or is global
- [ ] Service is restartable
- [ ] Service restart is zero-downtime
- [ ] Service is monitored (via prometheus and grafana)
- [ ] Service is not bound to one specific node (e.g. via files or volumes)
- [ ] Relevant OPS E2E Test are added
- [ ] Service's Public URL is included in maintenance mode
- [ ] Service's Public URL is included in testing mode -->
