### PR TITLE
Add cloudwatch grafana datasource

### DIFF
--- a/services/monitoring/grafana/Makefile
+++ b/services/monitoring/grafana/Makefile
@@ -27,7 +27,7 @@ terraform/plan.cache:
 	@exit 1
 
 .PHONY: terraform-plan
-terraform-plan: $(REPO_CONFIG_LOCATION) $(TF_STATE_FILE) ensure-grafana-online ## terraform plan
+terraform-plan: $(REPO_CONFIG_LOCATION) $(TF_STATE_FILE) ensure-grafana-online assets ## terraform plan
 	# terraform plan
 	@set -a; source $<; set +a; \
 	terraform -chdir=./terraform plan -out=plan.cache

--- a/services/monitoring/grafana/terraform/datasources.tf
+++ b/services/monitoring/grafana/terraform/datasources.tf
@@ -23,3 +23,18 @@ resource "grafana_data_source" "tempo" {
   basic_auth_enabled = false
   is_default         = false
 }
+
+resource "grafana_data_source" "cloudwatch" {
+  type = "cloudwatch"
+  name = "cloudwatch"
+
+  json_data_encoded = jsonencode({
+    defaultRegion = var.AWS_DEFAULT_REGION
+    authType      = "keys"
+  })
+
+  secure_json_data_encoded = jsonencode({
+    accessKey = var.AWS_GRAFANA_CLOUDWATCH_DATASOURCE_USER_ACCESS_KEY
+    secretKey = var.AWS_GRAFANA_CLOUDWATCH_DATASOURCE_USER_SECRET_KEY
+  })
+}

--- a/services/monitoring/grafana/terraform/variables.tf
+++ b/services/monitoring/grafana/terraform/variables.tf
@@ -18,3 +18,18 @@ variable "PROMETHEUS_CATCHALL_URL" {
   description = "Prometheus Catchall URL"
   sensitive   = false
 }
+
+variable "AWS_DEFAULT_REGION" {
+  description = "AWS Default Region"
+  sensitive   = false
+}
+
+variable "AWS_GRAFANA_CLOUDWATCH_DATASOURCE_USER_ACCESS_KEY" {
+  description = "AWS Grafana Cloudwatch User Access Key"
+  sensitive   = true
+}
+
+variable "AWS_GRAFANA_CLOUDWATCH_DATASOURCE_USER_SECRET_KEY" {
+  description = "AWS Grafana Cloudwatch User Secret Key"
+  sensitive   = true
+}

--- a/services/monitoring/prometheus/prometheus-simcore.yml
+++ b/services/monitoring/prometheus/prometheus-simcore.yml
@@ -92,7 +92,7 @@ scrape_configs:
       - names:
           - "tasks.production_rabbit"
           - "tasks.staging_rabbit"
-          - "task.master_rabbit"
+          - "tasks.master_rabbit"
         type: "A"
         port: 15692
       - names:


### PR DESCRIPTION
## What do these changes do?
This lets us build dashboards using cloudwatch metrics (aws managed
resources like RDS or MQ store their prometheus-like metrics there)

In future we can add dashboards for Postgres / Redis. Most likely we can reuse existing dashboards created by other people (for sure for RDS)

## Related issue/s
* https://github.com/ITISFoundation/osparc-ops-environments/issues/1048

## Related PR/s

## Checklist
- [ ] I tested and it works

<!--  Extra checks based on use case -->

<!-- New Stack Introduction
- [ ] The Stack has been included in CI Workflow
-->

<!-- New Service Introduction
- [ ] Service has resource limits and reservations
- [ ] Service has placement constraints or is global
- [ ] Service is restartable
- [ ] Service restart is zero-downtime
- [ ] Service is monitored (via prometheus and grafana)
- [ ] Service is not bound to one specific node (e.g. via files or volumes)
- [ ] Relevant OPS E2E Test are added
- [ ] Service's Public URL is included in maintenance mode
- [ ] Service's Public URL is included in testing mode -->
