### PR TITLE
Update RUT helmchart values

### DIFF
--- a/charts/simcore-charts/resource-usage-tracker/values.yaml.gotmpl
+++ b/charts/simcore-charts/resource-usage-tracker/values.yaml.gotmpl
@@ -2,7 +2,7 @@
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 
-replicaCount: 1
+replicaCount: {{ requiredEnv "RESOURCE_USAGE_TRACKER_KUBERNETES_REPLICAS" }}
 
 image:
   repository: '{{  .Values | get "DOCKER_REGISTRY" "itisfoundation" }}/resource-usage-tracker'
@@ -133,7 +133,7 @@ env:
   - name: RABBIT_USER
     value: {{ requiredEnv "RABBIT_USER" }}
   - name: REDIS_USER
-    value: {{ requiredEnv "REDIS_USER" }}
+    value: {{ env "REDIS_USER" }}
   - name: REDIS_HOST
     value: {{ requiredEnv "REDIS_EXTERNAL_HOST" }}
   - name: REDIS_PORT


### PR DESCRIPTION
## What do these changes do?
Make redis user non-required since on some deployments we don't use it Configure replica count with ENV

This is done withing preparations to move RUT to internal Kubernetes cluster

## Related issue/s
* https://github.com/ITISFoundation/osparc-ops-environments/issues/1052

## Related PR/s
* https://git.speag.com/oSparc/osparc-ops-deployment-configuration/-/merge_requests/1404

## Checklist
- [ ] I tested and it works

<!--  Extra checks based on use case -->

<!-- New Stack Introduction
- [ ] The Stack has been included in CI Workflow
-->

<!-- New Service Introduction
- [ ] Service has resource limits and reservations
- [ ] Service has placement constraints or is global
- [ ] Service is restartable
- [ ] Service restart is zero-downtime
- [ ] Service is monitored (via prometheus and grafana)
- [ ] Service is not bound to one specific node (e.g. via files or volumes)
- [ ] Relevant OPS E2E Test are added
- [ ] Service's Public URL is included in maintenance mode
- [ ] Service's Public URL is included in testing mode -->
