### PR TITLE
Fix director metrics port

### DIFF
--- a/services/monitoring/prometheus/prometheus-simcore.yml
+++ b/services/monitoring/prometheus/prometheus-simcore.yml
@@ -58,7 +58,7 @@ scrape_configs:
           - "tasks.staging_director"
           - "tasks.master_director"
         type: "A"
-        port: 8080
+        port: 8000
       - names:
           - "tasks.production_director-v2"
           - "tasks.staging_director-v2"


### PR DESCRIPTION
## What do these changes do?
This shall fix issue of lacking director metrics in grafana (prometheus scraping port is wrong)

## Related issue/s

## Related PR/s

## Checklist
- [x] I tested and it works

<!--  Extra checks based on use case -->

<!-- New Stack Introduction
- [ ] The Stack has been included in CI Workflow
-->

<!-- New Service Introduction
- [ ] Service has resource limits and reservations
- [ ] Service has placement constraints or is global
- [ ] Service is restartable
- [ ] Service restart is zero-downtime
- [ ] Service is monitored (via prometheus and grafana)
- [ ] Service is not bound to one specific node (e.g. via files or volumes)
- [ ] Relevant OPS E2E Test are added
- [ ] Service's Public URL is included in maintenance mode
- [ ] Service's Public URL is included in testing mode -->
