### PR TITLE
Document k8s pv removal

### DIFF
--- a/charts/aws-ebs-csi-driver/README.md
+++ b/charts/aws-ebs-csi-driver/README.md
@@ -1,0 +1,28 @@
+## How to delete volumes with `recalimPolicy: retain`
+1. Delete pvc:
+```
+kubectl delete pvc <pvc-name>
+```
+
+2. Verify PV is `released`
+```
+kubectl get pv <pv-name>
+```
+
+3. Manually remove EBS in AWS
+    1. Go to AWS GUI and List EBS Volumes
+    1. Filter by tag `ebs.csi.aws.com/cluster=true`
+    1. Identify the volume associated with your PV (check `kubernetes.io/created-for/pv/name` tag of the EBS Volume)
+    1. Verify that EBS Volume is `Available`
+    1. Delete EBS Volume
+
+4. Delete the PV
+```
+kubectl delete pv <pv-name>
+```
+
+5. Remove Finalizers (if necessary)
+If the PV remains in a Terminating state, remove its finalizers:
+```
+kubectl patch pv <pv-name> -p '{"metadata":{"finalizers":null}}'
+```

--- a/charts/victoria-logs/README.md
+++ b/charts/victoria-logs/README.md
@@ -1,2 +1,0 @@
-Highly Available Configuration with Helm:
-* https://github.com/VictoriaMetrics/VictoriaMetrics/issues/9076


### PR DESCRIPTION
## What do these changes do?
Currently aws ebs csi storage class is configured to retain persistent
volumes (pv) (safery measure). This documents how to remove PV(C)s and
corresponding AWS EBS Volume (to avoid accumulating hangling resources
and costs)

Minor:
* remove unnecessary Victoria Logs Readme

## Related issue/s

## Related PR/s
* https://github.com/ITISFoundation/osparc-ops-environments/pull/1063
* https://github.com/ITISFoundation/osparc-ops-environments/pull/916

## Checklist
- [x] I tested and it works

<!--  Extra checks based on use case -->

<!-- New Stack Introduction
- [ ] The Stack has been included in CI Workflow
-->

<!-- New Service Introduction
- [ ] Service has resource limits and reservations
- [ ] Service has placement constraints or is global
- [ ] Service is restartable
- [ ] Service restart is zero-downtime
- [ ] Service is monitored (via prometheus and grafana)
- [ ] Service is not bound to one specific node (e.g. via files or volumes)
- [ ] Relevant OPS E2E Test are added
- [ ] Service's Public URL is included in maintenance mode
- [ ] Service's Public URL is included in testing mode -->
