### PR TITLE
remove deprecated traefik labels

### DIFF
--- a/services/adminer/docker-compose.yml
+++ b/services/adminer/docker-compose.yml
@@ -13,7 +13,7 @@ services:
     deploy:
       labels:
         - traefik.enable=true
-        - traefik.docker.network=${PUBLIC_NETWORK}
+        - traefik.swarm.network=${PUBLIC_NETWORK}
         - traefik.http.services.adminer_simcore.loadbalancer.server.port=8080
         - traefik.http.routers.adminer_simcore.rule=Host(`${MONITORING_DOMAIN}`) && PathPrefix(`/adminer/simcore`)
         - traefik.http.routers.adminer_simcore.entrypoints=https

--- a/services/metabase/docker-compose.yml.j2
+++ b/services/metabase/docker-compose.yml.j2
@@ -43,7 +43,7 @@ services:
         - prometheus-port=9191
         # TODO: add prometheus metrics
         - traefik.enable=true
-        - traefik.docker.network=${PUBLIC_NETWORK}
+        - traefik.swarm.network=${PUBLIC_NETWORK}
         # router
         - traefik.http.routers.metabase.rule=Host(`${ADMIN_DOMAIN}`) && PathPrefix(`/metabase`)
         - traefik.http.routers.metabase.entrypoints=https

--- a/services/portainer/docker-compose.yml
+++ b/services/portainer/docker-compose.yml
@@ -54,7 +54,7 @@ services:
           - node.role == manager
       labels:
         - traefik.enable=true
-        - traefik.docker.network=${PUBLIC_NETWORK}
+        - traefik.swarm.network=${PUBLIC_NETWORK}
         - traefik.http.services.portainer.loadbalancer.server.port=9000
         - traefik.http.routers.portainer.rule=Host(`${MONITORING_DOMAIN}`) && PathPrefix(`/portainer`)
         - traefik.http.routers.portainer.entrypoints=https


### PR DESCRIPTION
## What do these changes do?
traefik v3 deprecated `traefik.docker.*` labels, and they should be replaced by `traefik.swarm.*` labels
## Related issue/s

## Related PR/s
- fixes https://github.com/ITISFoundation/osparc-ops-environments/issues/1106
## Checklist
- [ ] I tested and it works

<!--  Extra checks based on use case -->

<!-- New Stack Introduction
- [ ] The Stack has been included in CI Workflow
-->

<!-- New Service Introduction
- [ ] Service has resource limits and reservations
- [ ] Service has placement constraints or is global
- [ ] Service is restartable
- [ ] Service restart is zero-downtime
- [ ] Service has >1 replicas in PROD
- [ ] Service has docker heathlcheck enabled
- [ ] Service is monitored (via prometheus and grafana)
- [ ] Service is not bound to one specific node (e.g. via files or volumes)
- [ ] Relevant OPS E2E Test are added

If exposed via traefik
- [ ] Service's Public URL is included in maintenance mode
- [ ] Service's Public URL is included in testing mode
- [ ] Service's has Traefik (Service Loadbalancer) Healthcheck enabled
- [ ] Credentials page is updated
- [ ] Url added to e2e test services (e2e test checking that URL can be accessed)
-->
