### PR TITLE
inhouse tip prometheus: scrape simcore services

### DIFF
--- a/services/monitoring/Makefile
+++ b/services/monitoring/Makefile
@@ -71,7 +71,7 @@ docker-compose.dalco.yml: docker-compose.dalco.yml.j2 config.prometheus.ceph.sim
 	# generating $@
 	@$(call jinja,$<,.env,$@)
 
-docker-compose.public.yml: docker-compose.public.yml.j2 config.prometheus $(COMMON_COMPOSE_DEPENDENCIES)
+docker-compose.public.yml: docker-compose.public.yml.j2 config.prometheus.simcore $(COMMON_COMPOSE_DEPENDENCIES)
 	# generating $@
 	@$(call jinja,$<,.env,$@)
 


### PR DESCRIPTION
Rabibtmq and service grafana dashboard rely on data scraped from simcore. inhouse tip was not configured to scrape simcore services. This PR fixes it

## What do these changes do?

## Related issue/s
* closes https://github.com/ITISFoundation/osparc-ops-environments/issues/1088

## Related PR/s

## Checklist
- [x] I tested and it works

<!--  Extra checks based on use case -->

<!-- New Stack Introduction
- [ ] The Stack has been included in CI Workflow
-->

<!-- New Service Introduction
- [ ] Service has resource limits and reservations
- [ ] Service has placement constraints or is global
- [ ] Service is restartable
- [ ] Service restart is zero-downtime
- [ ] Service has >1 replicas in PROD
- [ ] Service has docker heathlcheck enabled
- [ ] Service is monitored (via prometheus and grafana)
- [ ] Service is not bound to one specific node (e.g. via files or volumes)
- [ ] Relevant OPS E2E Test are added

If exposed via traefik
- [ ] Service's Public URL is included in maintenance mode
- [ ] Service's Public URL is included in testing mode
- [ ] Service's has Traefik (Service Loadbalancer) Healthcheck enabled
- [ ] Credentials page is updated
- [ ] Url added to e2e test services (e2e test checking that URL can be accessed)
-->
