### PR TITLE
Kubernetes logging: storage configuration

### DIFF
--- a/charts/victoria-logs/values.ebs-storage.yaml.gotmpl
+++ b/charts/victoria-logs/values.ebs-storage.yaml.gotmpl
@@ -1,0 +1,5 @@
+server:
+  persistentVolume:
+    enabled: true
+    storageClassName: "{{ .Values.ebsStorageClassName }}"
+    size: 10Gi

--- a/charts/victoria-logs/values.topolvm-storage.yaml.gotmpl
+++ b/charts/victoria-logs/values.topolvm-storage.yaml.gotmpl
@@ -1,0 +1,5 @@
+server:
+  persistentVolume:
+    enabled: true
+    storageClassName: "{{ .Values.topolvmStorageClassName }}"
+    size: 10Gi

--- a/charts/victoria-logs/values.yaml.gotmpl
+++ b/charts/victoria-logs/values.yaml.gotmpl
@@ -29,11 +29,6 @@ server:
           - /logs
         pathType: Prefix
 
-  persistentVolume:
-    enabled: true
-    storageClassName: "{{ .Values.ebsStorageClassName }}"
-    size: 10Gi
-
   nodeSelector:
     ops: "true"
 


### PR DESCRIPTION
## What do these changes do?
Add ebs / topolvm storage configuration to run logging stack both on aws master and on internal master

## Related issue/s
* https://github.com/ITISFoundation/osparc-ops-environments/issues/1079

## Related PR/s
* https://git.speag.com/oSparc/osparc-ops-deployment-configuration/-/merge_requests/1478

## Checklist
- [x] I tested and it works

<!--  Extra checks based on use case -->

<!-- New Stack Introduction
- [ ] The Stack has been included in CI Workflow
-->

<!-- New Service Introduction
- [ ] Service has resource limits and reservations
- [ ] Service has placement constraints or is global
- [ ] Service is restartable
- [ ] Service restart is zero-downtime
- [ ] Service has >1 replicas in PROD
- [ ] Service has docker heathlcheck enabled
- [ ] Service is monitored (via prometheus and grafana)
- [ ] Service is not bound to one specific node (e.g. via files or volumes)
- [ ] Relevant OPS E2E Test are added

If exposed via traefik
- [ ] Service's Public URL is included in maintenance mode
- [ ] Service's Public URL is included in testing mode
- [ ] Service's has Traefik (Service Loadbalancer) Healthcheck enabled
- [ ] Credentials page is updated
- [ ] Url added to e2e test services (e2e test checking that URL can be accessed)
-->
