### PR TITLE
registry mirror: stop-first while updating

### DIFF
--- a/services/registry/docker-compose.yml.j2
+++ b/services/registry/docker-compose.yml.j2
@@ -109,7 +109,7 @@ services:
     deploy:
       mode: global
       update_config:
-        order: start-first
+        order: stop-first
         delay: 10s
         failure_action: rollback
         parallelism: 1


### PR DESCRIPTION
## What do these changes do?
Registry pull through cache service uses host port. New version of service cannot start while old is running since `host-mode port already in use…`

## Related issue/s

## Related PR/s
* https://github.com/ITISFoundation/osparc-ops-environments/issues/984

## Checklist
- [x] I tested and it works

<!--  Extra checks based on use case -->

<!-- New Stack Introduction
- [ ] The Stack has been included in CI Workflow
-->

<!-- New Service Introduction
- [ ] Service has resource limits and reservations
- [ ] Service has placement constraints or is global
- [ ] Service is restartable
- [ ] Service restart is zero-downtime
- [ ] Service has >1 replicas in PROD
- [ ] Service has docker heathlcheck enabled
- [ ] Service is monitored (via prometheus and grafana)
- [ ] Service is not bound to one specific node (e.g. via files or volumes)
- [ ] Relevant OPS E2E Test are added

If exposed via traefik
- [ ] Service's Public URL is included in maintenance mode
- [ ] Service's Public URL is included in testing mode
- [ ] Service's has Traefik (Service Loadbalancer) Healthcheck enabled
- [ ] Credentials page is updated
- [ ] Url added to e2e test services (e2e test checking that URL can be accessed)
-->
