### PR TITLE
Document metabase optional configuration (email, ...)

### DIFF
--- a/services/metabase/README.md
+++ b/services/metabase/README.md
@@ -6,3 +6,20 @@ Before deploying metabase first time, make sure that postgres is configured:
     * you can get one via adminer or by directly connecting to container and executing `psql -U <user> -d <db>`
 
 This can be automated via https://github.com/ITISFoundation/osparc-ops-environments/issues/827
+
+## Extra Configuration (optional)
+
+Setting up email (manual):
+* go to admin settings
+* go to email
+* configure email using SMTP_HOST, SMTP_PASSWORD, SMTP_PORT, SMTP_PROTOCOL, SMTP_USERNAME env from config
+  - Note: `FROM NAME` shall potentially clearly indicate deployment (if we use metabase in multiple deployments this helps to avoid confusion)
+  - Note: `FROM ADDRESS` use support email (we may consider adding a separate user and mail for metabase later)
+  - Note: `REPLY-TO ADDRESS` must NOT be support email. Feel free to choose some of backenders / devops email
+
+Configuring localization (manual):
+* go to admin settings
+* go to localization
+* configure first day of the week to be `Monday`
+
+Note: later these manual steps can be automated via Metabase API calls


### PR DESCRIPTION
## What do these changes do?
Steps are as of now manual and optional (metabase functions well without this configuration). Once we have more usage and traction of metabase we may consider automating these steps via Metabase API.

Email to be used is the same as for support. Once we see need, we can create separate email for metabase.

Note:
* The email functionality documented here was tested with different credentials. It worked fine :rocket: 

## Related Issue/s:
* https://github.com/ITISFoundation/osparc-ops-environments/issues/1114

## Related PR/s

## Checklist
- [x] I tested and it works

<!--  Extra checks based on use case -->

<!-- New Stack Introduction
- [ ] The Stack has been included in CI Workflow
-->

<!-- New Service Introduction
- [ ] Service has resource limits and reservations
- [ ] Service has placement constraints or is global
- [ ] Service is restartable
- [ ] Service restart is zero-downtime
- [ ] Service has >1 replicas in PROD
- [ ] Service has docker heathlcheck enabled
- [ ] Service is monitored (via prometheus and grafana)
- [ ] Service is not bound to one specific node (e.g. via files or volumes)
- [ ] Relevant OPS E2E Test are added

If exposed via traefik
- [ ] Service's Public URL is included in maintenance mode
- [ ] Service's Public URL is included in testing mode
- [ ] Service's has Traefik (Service Loadbalancer) Healthcheck enabled
- [ ] Credentials page is updated
- [ ] Url added to e2e test services (e2e test checking that URL can be accessed)
-->
