### PR TITLE
Kubernetes simcore: add pod security standard

### DIFF
--- a/charts/SECURITY.md
+++ b/charts/SECURITY.md
@@ -9,8 +9,8 @@ Full list: https://kubernetes.io/docs/concepts/security/application-security-che
 #### Pod-level securityContext recommendations
 
 Enable pod security standard on namespace level:
-* create namespace with labels https://aro-labs.com/pod-security-standards/
-* configure pod and container security context to satisfy security standards
+* create namespace with labels (examples and explanations https://aro-labs.com/pod-security-standards/)
+* configure pod and container security context to satisfy security standards (read more https://medium.com/dynatrace-engineering/kubernetes-security-part-3-security-context-7d44862c4cfa)
 
 ## Cluster / OPS developers
 

--- a/charts/SECURITY.md
+++ b/charts/SECURITY.md
@@ -1,0 +1,17 @@
+# Security
+
+This file documents security measures and their configuration in current code base
+
+## Application developer
+
+Full list: https://kubernetes.io/docs/concepts/security/application-security-checklist/
+
+#### Pod-level securityContext recommendations
+
+Enable pod security standard on namespace level:
+* create namespace with labels https://aro-labs.com/pod-security-standards/
+* configure pod and container security context to satisfy security standards
+
+## Cluster / OPS developers
+
+Full list: https://kubernetes.io/docs/concepts/security/security-checklist/

--- a/charts/simcore-charts/common-helpers/Chart.yaml
+++ b/charts/simcore-charts/common-helpers/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.0.1
+version: 0.0.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/simcore-charts/common-helpers/templates/_helpers.tpl
+++ b/charts/simcore-charts/common-helpers/templates/_helpers.tpl
@@ -72,3 +72,36 @@ data:
   {{- end }}
 {{- end }}
 {{- end -}}
+
+{{/*
+
+Usage:
+{{- include "common-helpers.defaultPodSecurityContext" . | nindent 0 }}
+
+Defines a common pod security context to ensure minimal privileges for containers.
+
+Values inspired from https://medium.com/dynatrace-engineering/kubernetes-security-part-3-security-context-7d44862c4cfa
+*/}}
+{{- define "common-helpers.defaultPodSecurityContext" -}}
+runAsNonRoot: true
+seccompProfile:
+  type: RuntimeDefault
+{{- end -}}
+
+{{/*
+
+Usage:
+{{- include "common-helpers.defaultContainerSecurityContext" . | nindent 0 }}
+
+Defines a common container security context to ensure minimal privileges for containers.
+
+Values inspired from https://medium.com/dynatrace-engineering/kubernetes-security-part-3-security-context-7d44862c4cfa
+*/}}
+{{- define "common-helpers.defaultContainerSecurityContext" -}}
+privileged: false
+readOnlyRootFilesystem: true
+allowPrivilegeEscalation: false
+capabilities:
+  drop:
+    - ALL
+{{- end -}}

--- a/charts/simcore-charts/namespace.yaml
+++ b/charts/simcore-charts/namespace.yaml
@@ -1,0 +1,16 @@
+# namespace with defined pod security standard
+# inspired from https://aro-labs.com/pod-security-standards/
+# official doc: https://kubernetes.io/docs/concepts/security/pod-security-standards/
+#
+# Warning: if pod / container does not meet enforced standards, it will not be deployed (silently)
+# execute `kubectl -n <namespace> events` to see errors (e.g.)
+#   Error creating: pods "xyz" is forbidden: violates PodSecurity "baseline:latest": privileged
+#   container "xyz" must not set securityContext.privileged to true
+#
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: simcore
+  labels:
+    pod-security.kubernetes.io/enforce: baseline
+    pod-security.kubernetes.io/warn: restricted

--- a/charts/simcore-charts/resource-usage-tracker/Chart.yaml
+++ b/charts/simcore-charts/resource-usage-tracker/Chart.yaml
@@ -4,7 +4,7 @@ description: A Helm chart for Kubernetes
 
 dependencies:
   - name: common-helpers
-    version: 0.0.1
+    version: 0.0.2
     repository: "file://../common-helpers"
 
 # A chart can be either an 'application' or a 'library' chart.
@@ -20,7 +20,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.0.1
+version: 0.0.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/simcore-charts/resource-usage-tracker/templates/deployment.yaml
+++ b/charts/simcore-charts/resource-usage-tracker/templates/deployment.yaml
@@ -29,11 +29,19 @@ spec:
       {{- end }}
       serviceAccountName: {{ include "resource-usage-tracker.serviceAccountName" . }}
       securityContext:
+      {{- if .Values.podSecurityContext }}
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      {{- else }}
+        {{- include "common-helpers.defaultPodSecurityContext" . | nindent 8 }}
+      {{- end }}
       containers:
         - name: {{ .Chart.Name }}
           securityContext:
+          {{- if .Values.securityContext }}
             {{- toYaml .Values.securityContext | nindent 12 }}
+          {{- else }}
+            {{- include "common-helpers.defaultContainerSecurityContext" . | nindent 12 }}
+          {{- end }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           env:

--- a/charts/simcore-charts/resource-usage-tracker/values.yaml.gotmpl
+++ b/charts/simcore-charts/resource-usage-tracker/values.yaml.gotmpl
@@ -28,16 +28,12 @@ serviceAccount:
 podAnnotations: {}
 podLabels: {}
 
-podSecurityContext: {}
-  # fsGroup: 2000
+podSecurityContext:
+  seccompProfile:
+    type: RuntimeDefault
 
-securityContext: {}
-  # capabilities:
-  #   drop:
-  #   - ALL
-  # readOnlyRootFilesystem: true
-  # runAsNonRoot: true
-  # runAsUser: 1000
+securityContext:
+  privileged: false
 
 service:
   type: ClusterIP


### PR DESCRIPTION
## What do these changes do?
Ensure baseline policy and warn on restricted policy violations. The k8s way to add pod security standard, is to add labels to the namespace. The adding labels to namespace is achieved via helmfile hooks. This policy forces pod to define some security settings (e.g. `privileged: false`). Read more https://kubernetes.io/docs/concepts/security/pod-security-standards/

WARNING: if deployed pod does not conform with baseline policy, it SILENTLY won't be scheduled. To see warnings / errors execute `kubectl -n simcore events'

Add helpful defaults for pod & container security context to ensure minimal privileges.

FYI: @pcrespov 

## Related issue/s
* https://github.com/ITISFoundation/osparc-ops-environments/issues/1137

## Related PR/s
* https://git.speag.com/oSparc/osparc-ops-deployment-configuration/-/merge_requests/1496

## Checklist
- [x] I tested and it works

<!--  Extra checks based on use case -->

<!-- New Stack Introduction
- [ ] The Stack has been included in CI Workflow
-->

<!-- New Service Introduction
- [ ] Service has resource limits and reservations
- [ ] Service has placement constraints or is global
- [ ] Service is restartable
- [ ] Service restart is zero-downtime
- [ ] Service has >1 replicas in PROD
- [ ] Service has docker heathlcheck enabled
- [ ] Service is monitored (via prometheus and grafana)
- [ ] Service is not bound to one specific node (e.g. via files or volumes)
- [ ] Relevant OPS E2E Test are added

If exposed via traefik
- [ ] Service's Public URL is included in maintenance mode
- [ ] Service's Public URL is included in testing mode
- [ ] Service's has Traefik (Service Loadbalancer) Healthcheck enabled
- [ ] Credentials page is updated
- [ ] Url added to e2e test services (e2e test checking that URL can be accessed)
-->
