### PR TITLE
Update k8s resource usage tracker chart lock

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -122,10 +122,10 @@ repos:
         always_run: true
         language: script
         files: '^(.*\/Makefile.*)|(.*\.deploy_everything_locally.bash)|(.*\/services/.*\/.*\.((sh)|(bash)))$'
-      - id: helm-deps
+      - id: helm-update-dependencies
         name: Helm Dependency Update
         description: Make sure all Chart.lock files are up-to-date
-        entry: bash -c 'find . -name Chart.yaml -exec dirname {} \; | xargs -t -I% helm dep up %'
+        entry: bash -c 'find . -name Chart.yaml -exec dirname {} \; | xargs -t -I% helm dependency update %'
         language: system
         files: ^charts/
         pass_filenames: false

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -122,3 +122,10 @@ repos:
         always_run: true
         language: script
         files: '^(.*\/Makefile.*)|(.*\.deploy_everything_locally.bash)|(.*\/services/.*\/.*\.((sh)|(bash)))$'
+      - id: helm-deps
+        name: Helm Dependency Update
+        description: Make sure all Chart.lock files are up-to-date
+        entry: bash -c 'find . -name Chart.yaml -exec dirname {} \; | xargs -t -I% helm dep up %'
+        language: system
+        files: ^charts/
+        pass_filenames: false

--- a/charts/simcore-charts/README.md
+++ b/charts/simcore-charts/README.md
@@ -1,6 +1,0 @@
-## Updating chart dependencies
-
-1. Execute `make helmfile-deps`
-2. Copy generated content to respective `Chart.lock`
-
-Avoid error: `Error: the lock file (Chart.lock) is out of sync with the dependencies file (Chart.yaml). Please update the dependencies`

--- a/charts/simcore-charts/README.md
+++ b/charts/simcore-charts/README.md
@@ -1,0 +1,6 @@
+## Updating chart dependencies
+
+1. Execute `make helmfile-deps`
+2. Copy generated content to respective `Chart.lock`
+
+Avoid error: `Error: the lock file (Chart.lock) is out of sync with the dependencies file (Chart.yaml). Please update the dependencies`

--- a/charts/simcore-charts/resource-usage-tracker/Chart.lock
+++ b/charts/simcore-charts/resource-usage-tracker/Chart.lock
@@ -3,4 +3,4 @@ dependencies:
   repository: file://../common-helpers
   version: 0.0.2
 digest: sha256:d6893dfacee6738bea269ee1ef0cec150d742d229541cde753b35f45fc1fa48a
-generated: "2025-07-21T13:36:38.485508045+02:00"
+generated: "2025-07-21T13:47:47.456513024+02:00"

--- a/charts/simcore-charts/resource-usage-tracker/Chart.lock
+++ b/charts/simcore-charts/resource-usage-tracker/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: common-helpers
   repository: file://../common-helpers
-  version: 0.0.1
-digest: sha256:5dad45e33a2acd921f5f907f9cabb434bb60f14bb799df95897661e95b302a26
-generated: "2024-08-29T11:15:50.206549321+02:00"
+  version: 0.0.2
+digest: sha256:d6893dfacee6738bea269ee1ef0cec150d742d229541cde753b35f45fc1fa48a
+generated: "2025-07-21T13:36:38.485508045+02:00"


### PR DESCRIPTION
## What do these changes do?
In https://github.com/ITISFoundation/osparc-ops-environments/pull/1139
resource usage tracker (RUT)  chart dependencies were updated but no
Chart.lock was not. This PRs updates Chart.lock (via helm dependency
update).

Bonus:
* Automate this with pre-commit hook

## Related issue/s

## Related PR/s
* fixes bug from https://github.com/ITISFoundation/osparc-ops-environments/pull/1139

## Checklist
- [x] I tested and it works

<!--  Extra checks based on use case -->

<!-- New Stack Introduction
- [ ] The Stack has been included in CI Workflow
-->

<!-- New Service Introduction
- [ ] Service has resource limits and reservations
- [ ] Service has placement constraints or is global
- [ ] Service is restartable
- [ ] Service restart is zero-downtime
- [ ] Service has >1 replicas in PROD
- [ ] Service has docker heathlcheck enabled
- [ ] Service is monitored (via prometheus and grafana)
- [ ] Service is not bound to one specific node (e.g. via files or volumes)
- [ ] Relevant OPS E2E Test are added

If exposed via traefik
- [ ] Service's Public URL is included in maintenance mode
- [ ] Service's Public URL is included in testing mode
- [ ] Service's has Traefik (Service Loadbalancer) Healthcheck enabled
- [ ] Credentials page is updated
- [ ] Url added to e2e test services (e2e test checking that URL can be accessed)
-->
