### PR TITLE
Kubernetes: refactor local cluster deployment

### DIFF
--- a/charts/Makefile
+++ b/charts/Makefile
@@ -1,3 +1,4 @@
+# to be executed on kubernetes control nodes
 REPO_BASE_DIR := $(shell git rev-parse --show-toplevel)
 
 include ${REPO_BASE_DIR}/scripts/common.Makefile
@@ -23,39 +24,15 @@ helmfile-lint: .check-helmfile-installed helmfile.yaml ## Lints the helmfile
 	set -a; source $(REPO_CONFIG_LOCATION); set +a; \
 	helmfile lint
 
-.PHONY: .helmfile-local-post-install
-.helmfile-local-post-install: ## Post install steps for local helmfile deployment
-	@$(MAKE) -s configure-local-hosts
-	@echo "";
-	@echo "Cluster has been deployed locally: https://$(MACHINE_FQDN)";
-	@echo "    For secure connections self-signed certificates are used.";
-	@echo "";
-
 .PHONY: helmfile-apply
 helmfile-apply: .check-helmfile-installed helmfile.yaml ## Applies the helmfile configuration
 	set -a; source $(REPO_CONFIG_LOCATION); set +a; \
 	helmfile -f $(REPO_BASE_DIR)/charts/helmfile.yaml apply
 
-	@if [ "$(MACHINE_FQDN)" = "osparc.local" ]; then \
-		$(MAKE) -s .helmfile-local-post-install; \
-	fi
-
 .PHONY: helmfile-sync
 helmfile-sync: .check-helmfile-installed helmfile.yaml ## Syncs the helmfile configuration (use `helmfile-apply` to deploy the app)
 	set -a; source $(REPO_CONFIG_LOCATION); set +a; \
 	helmfile -f $(REPO_BASE_DIR)/charts/helmfile.yaml sync
-
-	@if [ "$(MACHINE_FQDN)" = "osparc.local" ]; then \
-		$(MAKE) -s .helmfile-local-post-install; \
-	fi
-
-.PHONY: configure-local-hosts
-configure-local-hosts: $(REPO_CONFIG_LOCATION) ## Adds local hosts entries for the machine
-	# "Updating /etc/hosts with k8s $(MACHINE_FQDN) hosts ..."
-	@set -a; source $(REPO_CONFIG_LOCATION); set +a; \
-	grep -q "127.0.0.1 $$K8S_MONITORING_FQDN" /etc/hosts || echo "127.0.0.1 $$K8S_MONITORING_FQDN" | sudo tee -a /etc/hosts
-	@set -a; source $(REPO_CONFIG_LOCATION); set +a; \
-	grep -q "127.0.0.1 $$K8S_PRIVATE_FQDN" /etc/hosts || echo "127.0.0.1 $$K8S_PRIVATE_FQDN" | sudo tee -a /etc/hosts
 
 .PHONY: helmfile-diff
 helmfile-diff: .check-helmfile-installed helmfile.yaml ## Shows the differences that would be applied by helmfile

--- a/charts/README.md
+++ b/charts/README.md
@@ -45,7 +45,4 @@ helmfile init
 
 ## Running k8s cluster locally
 
-```bash
-cd ./osparc-ops-environments
-./scripts/create_local_k8s_cluster.bash
-```
+Use `./local-k8s.Makefile` targets

--- a/charts/local-k8s.Makefile
+++ b/charts/local-k8s.Makefile
@@ -1,0 +1,28 @@
+REPO_BASE_DIR := $(shell git rev-parse --show-toplevel)
+K8S_CLUSTER_NAME := osparc-cluster
+# Determine this makefile's path.
+# Be sure to place this BEFORE `include` directives, if any.
+THIS_MAKEFILE := $(lastword $(MAKEFILE_LIST))
+
+include ${REPO_BASE_DIR}/scripts/common.Makefile
+include $(REPO_CONFIG_LOCATION)
+
+create-cluster: ## Creates a local Kubernetes cluster
+	@$(REPO_BASE_DIR)/scripts/create_local_k8s_cluster.bash $(K8S_CLUSTER_NAME)
+	@$(MAKE) --no-print-directory --file $(THIS_MAKEFILE) configure-local-hosts
+	@echo "";
+	@echo "Cluster has been deployed locally: https://$(MACHINE_FQDN)";
+	@echo "    For secure connections self-signed certificates are used.";
+	@echo "";
+
+delete-cluster: ## Deletes the local Kubernetes cluster
+	@kind delete cluster --name $(K8S_CLUSTER_NAME)
+	@echo "Local Kubernetes cluster $(K8S_CLUSTER_NAME) has been deleted."
+
+.PHONY: configure-local-hosts
+configure-local-hosts: $(REPO_CONFIG_LOCATION) ## Adds local hosts entries for the machine
+	# "Updating /etc/hosts with k8s $(MACHINE_FQDN) hosts ..."
+	@set -a; source $(REPO_CONFIG_LOCATION); set +a; \
+	grep -q "127.0.0.1 $$K8S_MONITORING_FQDN" /etc/hosts || echo "127.0.0.1 $$K8S_MONITORING_FQDN" | sudo tee -a /etc/hosts
+	@set -a; source $(REPO_CONFIG_LOCATION); set +a; \
+	grep -q "127.0.0.1 $$K8S_PRIVATE_FQDN" /etc/hosts || echo "127.0.0.1 $$K8S_PRIVATE_FQDN" | sudo tee -a /etc/hosts

--- a/scripts/kind_config.yaml
+++ b/scripts/kind_config.yaml
@@ -13,3 +13,9 @@ nodes:
     labels:
       ops: "true"
       simcore: "true"
+
+# https://archive-os-3-26.netlify.app/calico/3.26/getting-started/kubernetes/kind/
+networking:
+  disableDefaultCNI: true
+  # must match with cidr in https://raw.githubusercontent.com/projectcalico/calico/v3.26.4/manifests/custom-resources.yaml
+  podSubnet: 192.168.0.0/16


### PR DESCRIPTION
## What do these changes do?
Changes
* Use calico CNI for networking as we use it in master deployments
* Move local-reated targets to a seperate Makefile (keep clean main Makefile used in master/stag/prod)
* Add delete (local) cluster target

## Related issue/s

## Related PR/s

## Checklist
- [x] I tested and it works

<!--  Extra checks based on use case -->

<!-- New Stack Introduction
- [ ] The Stack has been included in CI Workflow
-->

<!-- New Service Introduction
- [ ] Service has resource limits and reservations
- [ ] Service has placement constraints or is global
- [ ] Service is restartable
- [ ] Service restart is zero-downtime
- [ ] Service has >1 replicas in PROD
- [ ] Service has docker healthcheck enabled
- [ ] Service is monitored (via prometheus and grafana)
- [ ] Service is not bound to one specific node (e.g. via files or volumes)
- [ ] Relevant OPS E2E Test are added
- [ ] Grafana dashboards updated accordingly

If exposed via traefik
- [ ] Service's Public URL is included in maintenance mode
- [ ] Service's Public URL is included in testing mode
- [ ] Service's has Traefik (Service Loadbalancer) Healthcheck enabled
- [ ] Credentials page is updated
- [ ] Url added to e2e test services (e2e test checking that URL can be accessed)
-->
