### PR TITLE
Monitoring: add `wb-auth` scraping

### DIFF
--- a/services/monitoring/prometheus/prometheus-simcore.yml
+++ b/services/monitoring/prometheus/prometheus-simcore.yml
@@ -114,6 +114,12 @@ scrape_configs:
         type: "A"
         port: 8080
       - names:
+          - "tasks.production_wb-auth"
+          - "tasks.staging_wb-auth"
+          - "tasks.master_wb-auth"
+        type: "A"
+        port: 8080
+      - names:
           - "tasks.production_wb-api-server"
           - "tasks.staging_wb-api-server"
           - "tasks.master_wb-api-server"


### PR DESCRIPTION
## What do these changes do?
Add `wb-auth` to simcore scraping (which effectively scrapes + adds simcore specific labels like `service_name`)

It requires `/metrics` being exposed (aka diagnostics plugin in `wb-auth` must be enabled in simcore terminology)

## Related issue/s
* Solves missing metrics of `wb-auth` https://github.com/ITISFoundation/osparc-ops-environments/issues/1154

## Related PR/s
* Configuration https://git.speag.com/oSparc/osparc-ops-deployment-configuration/-/merge_requests/1521

## Checklist
- [x] I tested and it works

<!--  Extra checks based on use case -->

<!-- New Stack Introduction
- [ ] The Stack has been included in CI Workflow
-->

<!-- New Service Introduction
- [ ] Service has resource limits and reservations
- [ ] Service has placement constraints or is global
- [ ] Service is restartable
- [ ] Service restart is zero-downtime
- [ ] Service has >1 replicas in PROD
- [ ] Service has docker healthcheck enabled
- [ ] Service is monitored (via prometheus and grafana)
- [ ] Service is not bound to one specific node (e.g. via files or volumes)
- [ ] Relevant OPS E2E Test are added
- [ ] Grafana dashboards updated accordingly

If exposed via traefik
- [ ] Service's Public URL is included in maintenance mode
- [ ] Service's Public URL is included in testing mode
- [ ] Service's has Traefik (Service Loadbalancer) Healthcheck enabled
- [ ] Credentials page is updated
- [ ] Url added to e2e test services (e2e test checking that URL can be accessed)
-->
