### PR TITLE
Kubernetes: global deny network policy for simcore

### DIFF
--- a/charts/adminer/templates/networkpolicy.yaml
+++ b/charts/adminer/templates/networkpolicy.yaml
@@ -18,9 +18,3 @@ spec:
       destination:
         ports:
           - 5432
-    # allow dns requests to public dns servers
-    - action: Allow
-      protocol: UDP
-      destination:
-        ports:
-          - 53

--- a/charts/calico-configuration/README.md
+++ b/charts/calico-configuration/README.md
@@ -14,7 +14,7 @@ if calico version 3.30+ is installed
   - https://docs.tigera.io/calico/3.30/observability/view-flow-logs
 
 if calico version <= 3.29
-* create network policy with action log
+* create network policy with action log (read more https://docs.tigera.io/calico/latest/network-policy/policy-rules/log-rules)
   ```yaml
   apiVersion: projectcalico.org/v3
   kind: NetworkPolicy
@@ -25,7 +25,8 @@ if calico version <= 3.29
     ingress:
     - action: Log
   ```
-* apply policy and see logs via journalctl (you can grep with `calico-packet`)
+* apply policy and see logs via journalctl (you can grep with `calico-packet` on the node where the pod is running)
+* Note: one may implement policy step by step (allowing all traffic that is known and making last rule `Log` to see what traffic is still missing)
 
 ## Known issues
 
@@ -43,7 +44,7 @@ via calicoctl:
 
 Note:
 * global network policies and network policies are separate resources for calico
-* To see all resources execute `kubectl get crd | grep calico` or `calicoctl get --help`
+* To see all calico resources execute `kubectl get crd | grep calico` or `calicoctl get --help`
 
 Warning:
 * Network policies update are only applied to "new connections". To make them act, one may need to restart affected applications (pods)

--- a/charts/calico-configuration/templates/globalpolicy.yaml
+++ b/charts/calico-configuration/templates/globalpolicy.yaml
@@ -8,7 +8,7 @@ spec:
   # "calico-system", "calico-apiserver", "tigera-operator" -- calico namespaces (when installed via scripts [local deployment])
   # TODO: other namespaces are to be removed from this list (once appropriate network policies are created)
   namespaceSelector:
-    kubernetes.io/metadata.name not in {"kube-public", "kube-system", "kube-node-lease", "calico-system", "calico-apiserver", "tigera-operator", "simcore", "cert-manager", "reflector", "traefik", "victoria-logs", "csi-s3", "portainer", "topolvm", "local-path-storage", "longhorn"}
+    kubernetes.io/metadata.name not in {"kube-public", "kube-system", "kube-node-lease", "calico-system", "calico-apiserver", "tigera-operator", "cert-manager", "reflector", "traefik", "victoria-logs", "csi-s3", "portainer", "topolvm", "local-path-storage", "longhorn"}
   types:
     - Ingress
     - Egress

--- a/charts/calico-configuration/templates/globalpolicy.yaml
+++ b/charts/calico-configuration/templates/globalpolicy.yaml
@@ -22,9 +22,23 @@ spec:
         selector: 'k8s-app == "kube-dns"'
         ports:
           - 53
+    # nodelocaldns: https://github.com/kubernetes/kubernetes/blob/master/cluster/addons/dns/nodelocaldns/README.md#nodelocal-dns-cache
+    # IP from https://github.com/kubernetes-sigs/kubespray/blob/v2.24.1/roles/kubespray-defaults/defaults/main/main.yml#L108
+    - action: Allow
+      protocol: UDP
+      nets:
+        - 169.254.25.10/32
+      ports:
+        - 53
     - action: Allow
       protocol: TCP
       destination:
         selector: 'k8s-app == "kube-dns"'
         ports:
           - 53
+    - action: Allow
+      protocol: TCP
+      nets:
+        - 169.254.25.10/32
+      ports:
+        - 53

--- a/charts/simcore-charts/resource-usage-tracker/templates/deployment.yaml
+++ b/charts/simcore-charts/resource-usage-tracker/templates/deployment.yaml
@@ -13,9 +13,9 @@ spec:
       {{- include "resource-usage-tracker.selectorLabels" . | nindent 6 }}
   template:
     metadata:
-      {{- with .Values.podAnnotations }}
+      {{- if .Values.podAnnotations }}
       annotations:
-        {{- toYaml . | nindent 8 }}
+        {{- tpl (toYaml .Values.podAnnotations) . | nindent 8 }}
       {{- end }}
       labels:
         {{- include "resource-usage-tracker.labels" . | nindent 8 }}

--- a/charts/simcore-charts/resource-usage-tracker/templates/networkpolicy.yaml
+++ b/charts/simcore-charts/resource-usage-tracker/templates/networkpolicy.yaml
@@ -13,13 +13,6 @@ spec:
         ports:
           - {{ .Values.service.port }}
   egress:
-    # allow dns requests to public dns servers
-    - action: Allow
-      protocol: UDP
-      destination:
-        # allow DNS requests to public DNS servers
-        ports:
-          - 53
     - action: Allow
       protocol: TCP
       destination:

--- a/charts/simcore-charts/resource-usage-tracker/templates/networkpolicy.yaml
+++ b/charts/simcore-charts/resource-usage-tracker/templates/networkpolicy.yaml
@@ -23,15 +23,27 @@ spec:
     - action: Allow
       protocol: TCP
       destination:
+        nets:
+          - 10.0.0.0/8
+          - 192.168.0.0/16
+          - 172.16.0.0/12
         ports:
           - {{ .Values.networkPolicyEgressPorts.postgres }}
     - action: Allow
       protocol: TCP
       destination:
+        nets:
+          - 10.0.0.0/8
+          - 192.168.0.0/16
+          - 172.16.0.0/12
         ports:
           - {{ .Values.networkPolicyEgressPorts.redis }}
     - action: Allow
       protocol: TCP
       destination:
+        nets:
+          - 10.0.0.0/8
+          - 192.168.0.0/16
+          - 172.16.0.0/12
         ports:
           - {{ .Values.networkPolicyEgressPorts.rabbit }}

--- a/charts/simcore-charts/resource-usage-tracker/templates/networkpolicy.yaml
+++ b/charts/simcore-charts/resource-usage-tracker/templates/networkpolicy.yaml
@@ -1,0 +1,37 @@
+apiVersion: projectcalico.org/v3
+kind: NetworkPolicy
+metadata:
+  name: resource-usage-tracker-network-policy
+  labels:
+    {{- include "resource-usage-tracker.labels" . | nindent 4 }}
+spec:
+  selector: app.kubernetes.io/instance == "{{ .Release.Name }}"
+  ingress:
+    - action: Allow
+      protocol: TCP
+      destination:
+        ports:
+          - {{ .Values.service.port }}
+  egress:
+    # allow dns requests to public dns servers
+    - action: Allow
+      protocol: UDP
+      destination:
+        # allow DNS requests to public DNS servers
+        ports:
+          - 53
+    - action: Allow
+      protocol: TCP
+      destination:
+        ports:
+          - {{ .Values.networkPolicyEgressPorts.postgres }}
+    - action: Allow
+      protocol: TCP
+      destination:
+        ports:
+          - {{ .Values.networkPolicyEgressPorts.redis }}
+    - action: Allow
+      protocol: TCP
+      destination:
+        ports:
+          - {{ .Values.networkPolicyEgressPorts.rabbit }}

--- a/charts/simcore-charts/resource-usage-tracker/values.yaml.gotmpl
+++ b/charts/simcore-charts/resource-usage-tracker/values.yaml.gotmpl
@@ -25,7 +25,9 @@ serviceAccount:
   # If not set and create is true, a name is generated using the fullname template
   name: ""
 
-podAnnotations: {}
+podAnnotations:
+  checksum/networkpolicy: '{{`{{ include (print $.Template.BasePath "/networkpolicy.yaml") . | sha256sum }}`}}'
+
 podLabels: {}
 
 podSecurityContext:
@@ -150,3 +152,8 @@ env:
   - name: RESOURCE_USAGE_TRACKER_S3
     value: {{ requiredEnv "RESOURCE_USAGE_TRACKER_S3" | quote }}  # without quote `null` won't work
     sensitive: true
+
+networkPolicyEgressPorts:
+  rabbit: {{ requiredEnv "RABBIT_EXTERNAL_PORT" }}
+  redis: {{ requiredEnv "REDIS_EXTERNAL_PORT" }}
+  postgres: {{ requiredEnv "POSTGRES_EXTERNAL_PORT" }}


### PR DESCRIPTION
## What do these changes do?
Apply global deny network policy for all applications running in `simcore` namespace

Add explicit network policy for simcore rut to allow traffic. Add network policy checksum annotation to rut deployment to restart rut pods on policy changes and thus be sure new network rules are used

Pin point extra dns request sent to nodelocaldns service and allow this traffic in global policy (update adminer network policy correspondingly)

Update calico configuration Readme to give more details how to create / debug network policies

FYI: @pcrespov @sanderegg @GitHK 

## Related issue/s
* closes https://github.com/ITISFoundation/osparc-ops-environments/issues/1168

## Related PR/s

## Checklist
- [x] I tested and it works

<!--  Extra checks based on use case -->

<!-- New Stack Introduction
- [ ] The Stack has been included in CI Workflow
-->

<!-- New Service Introduction
- [ ] Service has resource limits and reservations
- [ ] Service has placement constraints or is global
- [ ] Service is restartable
- [ ] Service restart is zero-downtime
- [ ] Service has >1 replicas in PROD
- [ ] Service has docker healthcheck enabled
- [ ] Service is monitored (via prometheus and grafana)
- [ ] Service is not bound to one specific node (e.g. via files or volumes)
- [ ] Relevant OPS E2E Test are added
- [ ] Grafana dashboards updated accordingly

If exposed via traefik
- [ ] Service's Public URL is included in maintenance mode
- [ ] Service's Public URL is included in testing mode
- [ ] Service's has Traefik (Service Loadbalancer) Healthcheck enabled
- [ ] Credentials page is updated
- [ ] Url added to e2e test services (e2e test checking that URL can be accessed)
-->
