### PR TITLE
Fix validate simcore settings script

### DIFF
--- a/scripts/deployments/validate_simcore_stack_yml.bash
+++ b/scripts/deployments/validate_simcore_stack_yml.bash
@@ -82,6 +82,12 @@ for service in $($_yq e '.services | keys | .[]' ${COMPOSE_FILE}); do
     if [ "${TARGETNAME}" == "docker-api-proxy" ]; then
         continue
     fi
+    if [ "${TARGETNAME}" == "traefik-configuration-placeholder" ]; then
+        continue
+    fi
+    if [ "${TARGETNAME}" == "ops-traefik-configuration-placeholder" ]; then
+        continue
+    fi
     export TARGET_BINARY="simcore-service"
     echo "Assuming TARGET_BINARY in ${SETTINGS_BINARY_PATH}/${TARGET_BINARY}"
     # Pull image from registry, just in case


### PR DESCRIPTION
## What do these changes do?
Remove traefik configuration services from validation simcore settings

## Related issue/s
* closes https://github.com/ITISFoundation/osparc-ops-environments/issues/1166

## Related PR/s

## Checklist
- [ ] I tested and it works

<!--  Extra checks based on use case -->

<!-- New Stack Introduction
- [ ] The Stack has been included in CI Workflow
-->

<!-- New Service Introduction
- [ ] Service has resource limits and reservations
- [ ] Service has placement constraints or is global
- [ ] Service is restartable
- [ ] Service restart is zero-downtime
- [ ] Service has >1 replicas in PROD
- [ ] Service has docker healthcheck enabled
- [ ] Service is monitored (via prometheus and grafana)
- [ ] Service is not bound to one specific node (e.g. via files or volumes)
- [ ] Relevant OPS E2E Test are added
- [ ] Grafana dashboards updated accordingly

If exposed via traefik
- [ ] Service's Public URL is included in maintenance mode
- [ ] Service's Public URL is included in testing mode
- [ ] Service's has Traefik (Service Loadbalancer) Healthcheck enabled
- [ ] Credentials page is updated
- [ ] Url added to e2e test services (e2e test checking that URL can be accessed)
-->
