### PR TITLE
Simcore: remove rollback update policy

### DIFF
--- a/services/simcore/docker-compose.yml.j2
+++ b/services/simcore/docker-compose.yml.j2
@@ -346,7 +346,7 @@ services:
       update_config:
         parallelism: 2
         order: start-first
-        failure_action: rollback
+        failure_action: continue
         delay: 10s
       restart_policy:
         condition: any
@@ -415,7 +415,7 @@ services:
       update_config:
         parallelism: 1
         order: start-first
-        failure_action: rollback
+        failure_action: continue
         delay: 10s
       placement:
         constraints:
@@ -436,7 +436,7 @@ services:
       update_config:
         parallelism: 1
         order: start-first
-        failure_action: rollback
+        failure_action: continue
         delay: 10s
       placement:
         constraints:
@@ -1066,7 +1066,7 @@ services:
       update_config:
         parallelism: 1
         order: start-first
-        failure_action: rollback
+        failure_action: continue
         delay: 10s
       resources:
         limits:


### PR DESCRIPTION
## What do these changes do?
simcore service should all be using the same version. Version mismatches are not expected (developers do not take backwarn compatibility between simcore service versions into account). Also simcore services using database expect a migraton version to match (directly related to version).

FYI: @pcrespov @sanderegg @GitHK @bisgaard-itis 

## Related issue/s
* closes https://github.com/ITISFoundation/osparc-ops-environments/issues/1167

## Related PR/s

## Checklist
- [x] I tested and it works

<!--  Extra checks based on use case -->

<!-- New Stack Introduction
- [ ] The Stack has been included in CI Workflow
-->

<!-- New Service Introduction
- [ ] Service has resource limits and reservations
- [ ] Service has placement constraints or is global
- [ ] Service is restartable
- [ ] Service restart is zero-downtime
- [ ] Service has >1 replicas in PROD
- [ ] Service has docker healthcheck enabled
- [ ] Service is monitored (via prometheus and grafana)
- [ ] Service is not bound to one specific node (e.g. via files or volumes)
- [ ] Relevant OPS E2E Test are added
- [ ] Grafana dashboards updated accordingly

If exposed via traefik
- [ ] Service's Public URL is included in maintenance mode
- [ ] Service's Public URL is included in testing mode
- [ ] Service's has Traefik (Service Loadbalancer) Healthcheck enabled
- [ ] Credentials page is updated
- [ ] Url added to e2e test services (e2e test checking that URL can be accessed)
-->
