### PR TITLE
FluentD configuration: remove `/` in front of container names

### DIFF
--- a/services/logging/fluentd/fluent.conf
+++ b/services/logging/fluentd/fluent.conf
@@ -42,6 +42,16 @@
   </record>
 </filter>
 
+# Clean container names (Ruby needed)
+<filter docker.**>
+  @type record_transformer
+  enable_ruby true
+  <record>
+    container_name ${record["container_name"] ? record["container_name"].sub(/^\//, '') : record["container_name"]}
+  </record>
+</filter>
+
+
 # Output to both Graylog (GELF) and Loki
 <match docker.**>
   @type copy

--- a/services/logging/fluentd/fluent.conf
+++ b/services/logging/fluentd/fluent.conf
@@ -42,7 +42,7 @@
   </record>
 </filter>
 
-# Clean container names (Ruby needed)
+# Clean container names (Ruby needed) by removing leading slashes
 <filter docker.**>
   @type record_transformer
   enable_ruby true


### PR DESCRIPTION
## What do these changes do?

## Related issue/s

## Related PR/s
* https://github.com/ITISFoundation/osparc-ops-environments/pull/1058

## Checklist
- [x] I tested and it works

<!--  Extra checks based on use case -->

<!-- New Stack Introduction
- [ ] The Stack has been included in CI Workflow
-->

<!-- New Service Introduction
- [ ] Service has resource limits and reservations
- [ ] Service has placement constraints or is global
- [ ] Service is restartable
- [ ] Service restart is zero-downtime
- [ ] Service has >1 replicas in PROD
- [ ] Service has docker healthcheck enabled
- [ ] Service is monitored (via prometheus and grafana)
- [ ] Service is not bound to one specific node (e.g. via files or volumes)
- [ ] Relevant OPS E2E Test are added
- [ ] Grafana dashboards updated accordingly

If exposed via traefik
- [ ] Service's Public URL is included in maintenance mode
- [ ] Service's Public URL is included in testing mode
- [ ] Service's has Traefik (Service Loadbalancer) Healthcheck enabled
- [ ] Credentials page is updated
- [ ] Url added to e2e test services (e2e test checking that URL can be accessed)
-->
