### PR TITLE
FluentD configuration trial 2

### DIFF
--- a/services/logging/fluentd/fluent.conf
+++ b/services/logging/fluentd/fluent.conf
@@ -32,6 +32,7 @@
   bind 0.0.0.0
   # Add source hostname to records
   source_hostname_key source_hostname
+  resolve_hostname true
 </source>
 
 # Add additional metadata

--- a/services/logging/fluentd/fluent.conf
+++ b/services/logging/fluentd/fluent.conf
@@ -47,6 +47,7 @@
 <filter docker.**>
   @type record_transformer
   enable_ruby true
+  remove_keys source_hostname  # Remove the redundant source_hostname field
   <record>
     # cleanup container names by removing leading slashes
     container_name ${record["container_name"] ? record["container_name"].sub(/^\//, '') : record["container_name"]}


### PR DESCRIPTION
## What do these changes do?
As noticed by @YuryHrytsuk the `source` and `source_hostname` are duplicates. this was fixed.
As noticed by @YuryHrytsuk the `source` shows an IP in on-premise clusters that does not ring a bell. this was not fixed yet, and in AWS clusters the `source` reports the AWS private DNS, which is kind of ok.


## Related issue/s

## Related PR/s

## Checklist
- [ ] I tested and it works

<!--  Extra checks based on use case -->

<!-- New Stack Introduction
- [ ] The Stack has been included in CI Workflow
-->

<!-- New Service Introduction
- [ ] Service has resource limits and reservations
- [ ] Service has placement constraints or is global
- [ ] Service is restartable
- [ ] Service restart is zero-downtime
- [ ] Service has >1 replicas in PROD
- [ ] Service has docker healthcheck enabled
- [ ] Service is monitored (via prometheus and grafana)
- [ ] Service is not bound to one specific node (e.g. via files or volumes)
- [ ] Relevant OPS E2E Test are added
- [ ] Grafana dashboards updated accordingly

If exposed via traefik
- [ ] Service's Public URL is included in maintenance mode
- [ ] Service's Public URL is included in testing mode
- [ ] Service's has Traefik (Service Loadbalancer) Healthcheck enabled
- [ ] Credentials page is updated
- [ ] Url added to e2e test services (e2e test checking that URL can be accessed)
-->
