### PR TITLE
Add api-worker simcore service

### DIFF
--- a/services/simcore/docker-compose.yml.j2
+++ b/services/simcore/docker-compose.yml.j2
@@ -117,6 +117,25 @@ services:
           memory: "600M"
     extra_hosts: []
 
+  api-worker:
+    deploy:
+      replicas: ${SIMCORE_API_WORKER_REPLICAS}
+      update_config:
+        parallelism: 1
+        order: start-first
+        failure_action: continue
+        delay: 10s
+      placement:
+        constraints:
+          - node.labels.simcore==true
+      resources:
+        reservations:
+          cpus: "0.1"
+          memory: "256M"
+        limits: # Wait for MB to estimate real numbers
+          cpus: "1.0"
+          memory: "500M"
+
   catalog:
     networks:
       - monitored

--- a/services/simcore/docker-compose.yml.j2
+++ b/services/simcore/docker-compose.yml.j2
@@ -133,7 +133,7 @@ services:
           cpus: "0.1"
           memory: "256M"
         limits: # Wait for MB to estimate real numbers
-          cpus: "1.0"
+          cpus: "1.5"
           memory: "500M"
 
   catalog:


### PR DESCRIPTION
## What do these changes do?


## Related issue/s
* closes https://github.com/ITISFoundation/osparc-ops-environments/issues/1192

## Related PR/s
* https://github.com/ITISFoundation/osparc-simcore/pull/8233
- [ ] must be merged before :point_right:  configuration changes https://git.speag.com/oSparc/osparc-ops-deployment-configuration/-/merge_requests/1571

## Checklist
- [ ] I tested and it works
- [x] The Stack has been included in CI Workflow

New service
- [x] Service has resource limits and reservations
- [x] Service has placement constraints or is global
- [x] Service is restartable
- [x] Service restart is zero-downtime
- [x] Service has >1 replicas in PROD
- [x] Service has docker healthcheck enabled --> defined in docker image
- [ ] ~~Service is monitored~~ (via prometheus and grafana) --> tracing and prometheus metrics endpoint are not exposed on this service
- [x] Service is not bound to one specific node (e.g. via files or volumes)
- [ ] ~~Relevant OPS E2E Test are added~~ --> no special e2e ops tests needed
- [ ] ~~Grafana dashboards updated accordingly~~ --> no special changes necessary

If exposed via traefik --> **not applicable**
- [ ] Service's Public URL is included in maintenance mode
- [ ] Service's Public URL is included in testing mode
- [ ] Service's has Traefik (Service Loadbalancer) Healthcheck enabled
- [ ] Credentials page is updated
- [ ] Url added to e2e test services (e2e test checking that URL can be accessed)

