### PR TITLE
Kubernetes Monitoring: add prometheus

### DIFF
--- a/charts/kube-prometheus-stack/values.yaml.gotmpl
+++ b/charts/kube-prometheus-stack/values.yaml.gotmpl
@@ -1,0 +1,97 @@
+alertmanager:
+  enabled: false
+
+defaultRules:
+  create: false
+
+grafana:
+  enabled: false
+
+kubeApiServer:
+  enabled: false
+
+kubelet:
+  enabled: false
+
+kubeControllerManager:
+  enabled: false
+
+coreDns:
+  enabled: false
+
+kubeEtcd:
+  enabled: false
+
+kubeScheduler:
+  enabled: false
+
+kubeDns:
+  enabled: false
+
+kubeProxy:
+  enabled: false
+
+kubeStateMetrics:
+  enabled: false
+
+nodeExporter:
+  enabled: true
+
+thanosRuler:
+  enabled: false
+
+prometheusOperator:
+  enabled: true
+
+  networkPolicy: &networkPolicy
+    enabled: true
+    flavor: Kubernetes
+
+  resources:
+    limits:
+      cpu: 1
+      memory: 1Gi
+    requests:
+      cpu: 0.1
+      memory: 256Mi
+
+  nodeSelector:
+    ops: "true"
+
+prometheus:
+  enabled: true
+
+  networkPolicy: *networkPolicy
+
+  # enable once needed (object storage)
+  thanosService:
+    enabled: false
+
+  ingress:
+    enabled: true
+    annotations:
+        namespace: "{{ .Release.Namespace }}"
+        cert-manager.io/cluster-issuer: "cert-issuer"
+        traefik.ingress.kubernetes.io/router.entrypoints: websecure
+        traefik.ingress.kubernetes.io/router.middlewares: traefik-traefik-basic-auth@kubernetescrd # namespace + middleware name
+    tls:
+      - secretName: monitoring-tls
+        hosts:
+          - {{ requiredEnv "K8S_MONITORING_FQDN" }}
+    hosts:
+      - {{ requiredEnv "K8S_MONITORING_FQDN" }}
+    paths:
+      - /prometheus &pathprefix
+    pathType: Prefix
+
+  prometheusSpec:
+    routePrefix: *pathprefix
+
+    retention: 90d
+
+    retentionSize: 100GiB
+
+    scrape_interval: 15s
+
+    nodeSelector:
+      ops: "true"

--- a/charts/monitoring/namespace.yaml
+++ b/charts/monitoring/namespace.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: monitoring
+  labels:
+    pod-security.kubernetes.io/enforce: restricted


### PR DESCRIPTION
## What do these changes do?

## Related issue/s
* https://github.com/ITISFoundation/osparc-ops-environments/issues/1222

## Related PR/s

## Checklist
- [ ] I tested and it works

<!--  Extra checks based on use case -->

<!-- New Stack Introduction
- [ ] The Stack has been included in CI Workflow
-->

<!-- New Service Introduction
- [ ] Service has resource limits and reservations
- [ ] Service has placement constraints or is global
- [ ] Service is restartable
- [ ] Service restart is zero-downtime
- [ ] Service has >1 replicas in PROD
- [ ] Service has docker healthcheck enabled
- [ ] Service is monitored (via prometheus and grafana)
- [ ] Service is not bound to one specific node (e.g. via files or volumes)
- [ ] Relevant OPS E2E Test are added
- [ ] Grafana dashboards updated accordingly

If exposed via traefik
- [ ] Service's Public URL is included in maintenance mode
- [ ] Service's Public URL is included in testing mode
- [ ] Service's has Traefik (Service Loadbalancer) Healthcheck enabled
- [ ] Credentials page is updated
- [ ] Url added to e2e test services (e2e test checking that URL can be accessed)
-->
