### PR TITLE
Kubernetes: fix global network policy

### DIFF
--- a/charts/calico-configuration/templates/globalpolicy.yaml
+++ b/charts/calico-configuration/templates/globalpolicy.yaml
@@ -26,10 +26,11 @@ spec:
     # IP from https://github.com/kubernetes-sigs/kubespray/blob/v2.24.1/roles/kubespray-defaults/defaults/main/main.yml#L108
     - action: Allow
       protocol: UDP
-      nets:
-        - 169.254.25.10/32
-      ports:
-        - 53
+      destination:
+        nets:
+          - 169.254.25.10/32
+        ports:
+          - 53
     - action: Allow
       protocol: TCP
       destination:
@@ -38,7 +39,8 @@ spec:
           - 53
     - action: Allow
       protocol: TCP
-      nets:
-        - 169.254.25.10/32
-      ports:
-        - 53
+      destination:
+        nets:
+          - 169.254.25.10/32
+        ports:
+          - 53


### PR DESCRIPTION
## What do these changes do?

## Related issue/s
* closes https://github.com/ITISFoundation/osparc-ops-environments/issues/1226

## Related PR/s

## Checklist
- [x] I tested and it works

<!--  Extra checks based on use case -->

<!-- New Stack Introduction
- [ ] The Stack has been included in CI Workflow
-->

<!-- New Service Introduction
- [ ] Service has resource limits and reservations
- [ ] Service has placement constraints or is global
- [ ] Service is restartable
- [ ] Service restart is zero-downtime
- [ ] Service has >1 replicas in PROD
- [ ] Service has docker healthcheck enabled
- [ ] Service is monitored (via prometheus and grafana)
- [ ] Service is not bound to one specific node (e.g. via files or volumes)
- [ ] Relevant OPS E2E Test are added
- [ ] Grafana dashboards updated accordingly

If exposed via traefik
- [ ] Service's Public URL is included in maintenance mode
- [ ] Service's Public URL is included in testing mode
- [ ] Service's has Traefik (Service Loadbalancer) Healthcheck enabled
- [ ] Credentials page is updated
- [ ] Url added to e2e test services (e2e test checking that URL can be accessed)
-->
